### PR TITLE
fix: postgres init-databases.sh psql variable syntax error

### DIFF
--- a/docker/postgres/init-databases.sh
+++ b/docker/postgres/init-databases.sh
@@ -4,18 +4,13 @@ set -euo pipefail
 # Create service metadata databases during the first Postgres initialization.
 create_database() {
   local database="$1"
-  local exists
 
-  exists="$(
-    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres --set=database="$database" \
-      --tuples-only --no-align \
-      --command "SELECT 1 FROM pg_database WHERE datname = :'database'"
-  )"
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres \
+    --command "SELECT 1 FROM pg_database WHERE datname = '$database'" \
+    --tuples-only --no-align | grep -q 1 && return 0
 
-  if [[ "$exists" != "1" ]]; then
-    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres --set=database="$database" \
-      --command 'CREATE DATABASE :"database"'
-  fi
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres \
+    --command "CREATE DATABASE \"$database\""
 }
 
 create_database "${KOIN_DATA_AIRFLOW_DB:-airflow_metadata}"


### PR DESCRIPTION
## Summary
- `docker/postgres/init-databases.sh`의 psql `--set` 변수 치환 문법(`:variable`)이 postgres:16 이미지에서 동작하지 않는 버그 수정
- 이 버그로 인해 `airflow_metadata`, `superset_metadata` DB가 초기화 시 생성되지 않아 Airflow/Superset 컨테이너가 시작 불가한 상태가 됨
- psql 변수 치환 대신 일반 쿼리 문자열 방식으로 교체

## Test plan
- [ ] `docker compose down -v && docker compose up -d` 실행 시 Airflow/Superset이 정상 기동되는지 확인
- [ ] postgres 컨테이너 로그에 init-databases.sh 에러 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database initialization process with internal optimizations to the initialization script.

---

**Note:** This release contains technical infrastructure improvements with no visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->