### PR TITLE
fix: postgres init-databases.sh psql variable syntax for postgres:16

### DIFF
--- a/docker/postgres/init-databases.sh
+++ b/docker/postgres/init-databases.sh
@@ -4,18 +4,14 @@ set -euo pipefail
 # Create service metadata databases during the first Postgres initialization.
 create_database() {
   local database="$1"
-  local exists
 
-  exists="$(
-    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres --set=database="$database" \
-      --tuples-only --no-align \
-      --command "SELECT 1 FROM pg_database WHERE datname = :'database'"
-  )"
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres \
+    --tuples-only --no-align \
+    --command "SELECT 1 FROM pg_database WHERE datname = '$database'" \
+    | grep -q 1 && return 0
 
-  if [[ "$exists" != "1" ]]; then
-    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres --set=database="$database" \
-      --command 'CREATE DATABASE :"database"'
-  fi
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres \
+    --command "CREATE DATABASE \"$database\""
 }
 
 create_database "${KOIN_DATA_AIRFLOW_DB:-airflow_metadata}"


### PR DESCRIPTION
## Summary

- `--set` + `:'variable'` 방식이 postgres:16 Docker 이미지의 `--command` 모드에서 동작하지 않는 버그 수정
- bash 변수 직접 삽입 방식으로 교체
- 서버 첫 배포 시 볼륨이 없는 상태에서 `airflow_metadata`, `superset_metadata` DB가 생성되지 않는 문제 해결

## Root Cause

psql의 `--set=var=value` + `:'var'` 변수 치환은 인터랙티브/스크립트 모드에서는 동작하지만, `--command` 플래그와 함께 쓰면 postgres:16에서 치환이 발생하지 않아 SQL 에러로 init 스크립트 전체가 종료됨.

볼륨이 이미 있는 경우 init 스크립트가 스킵되므로 기존 환경에서는 재현되지 않음.

## Test plan

- [ ] `docker compose down -v` 후 `docker compose up -d` 로 볼륨 없는 첫 실행 테스트
- [ ] `airflow_metadata`, `superset_metadata` DB 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database setup reliability during startup by making existing databases easier to detect before creation.
  * Reduced the chance of duplicate database creation attempts when initializing Postgres.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->