### PR TITLE
chore: expose Airflow and Superset ports for Tailscale access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     <<: *airflow-common
     command: api-server
     ports:
-      - "127.0.0.1:${KOIN_DATA_AIRFLOW_PORT:-8080}:8080"
+      - "${KOIN_DATA_AIRFLOW_PORT:-8080}:8080"
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v2/monitor/health"]
       interval: 30s
@@ -110,7 +110,7 @@ services:
       - ./docker/superset/superset_config.py:/app/pythonpath/superset_config.py:ro
       - ./secrets:/app/secrets:ro
     ports:
-      - "127.0.0.1:${KOIN_DATA_SUPERSET_PORT:-8088}:8088"
+      - "${KOIN_DATA_SUPERSET_PORT:-8088}:8088"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- Airflow(8080), Superset(8088) 포트 바인딩을 `127.0.0.1` → `0.0.0.0`으로 변경
- Tailscale 연결된 운영자가 SSH 터널 없이 직접 접속 가능
- Lightsail 방화벽이 8080/8088을 인터넷에 차단하고 있으므로 외부 노출 없음

## 접속 방법 (머지 후)

Tailscale 연결 상태에서 브라우저에서 바로:
- `http://100.80.218.102:8080` → Airflow
- `http://100.80.218.102:8088` → Superset

## Test plan

- [ ] 서버에서 `docker compose up -d` 재시작
- [ ] Tailscale 연결 상태에서 `http://100.80.218.102:8080` 접속 확인
- [ ] Tailscale 연결 상태에서 `http://100.80.218.102:8088` 접속 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Airflow webserver and Superset are now reachable on configurable ports and can be accessed from all network interfaces.
  * Default ports remain 8080 and 8088 unless overridden by environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->