### PR TITLE
fix: persist Airflow password file via volume mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ data/
 
 airflow/logs/
 airflow/**/__pycache__/
+airflow/passwords.json
 
 dbt/**/target/
 dbt/**/dbt_packages/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ x-airflow-common: &airflow-common
     - ./airflow/plugins:/opt/airflow/plugins
     - ./airflow/logs:/opt/airflow/logs
     - ./secrets:/opt/airflow/secrets:ro
+    - ./airflow/passwords.json:/opt/airflow/simple_auth_manager_passwords.json.generated
   depends_on:
     postgres:
       condition: service_healthy


### PR DESCRIPTION
## Summary

- `airflow/passwords.json` 을 컨테이너에 볼륨 마운트
- `docker compose down` 후 재시작해도 비밀번호 유지됨
- `passwords.json` 은 `.gitignore` 처리 — 서버에서 직접 생성 필요

## 서버 초기 설정

```bash
echo '{"admin": "admin1234"}' > ~/KOIN_DATA/airflow/passwords.json
```

## Test plan

- [ ] 서버에서 `passwords.json` 생성
- [ ] `docker compose up -d` 재시작
- [ ] `http://100.80.218.102:8080` 에서 admin/admin1234 로그인 확인
- [ ] `docker compose down && docker compose up -d` 후에도 동일 비번으로 로그인 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)