### PR TITLE
feat: dbt BigQuery 프로젝트 뼈대 + 로컬 stage 연결

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -1,0 +1,23 @@
+name: 'koin_data'
+version: '1.0.0'
+config-version: 2
+
+profile: 'koin_data'
+
+model-paths: ["models"]
+macro-paths: ["macros"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+
+clean-targets:
+  - "target"
+  - "dbt_packages"
+
+models:
+  koin_data:
+    silver:         # Silver 레이어 (정제 + 비즈니스 로직)
+      +materialized: view
+      +schema: silver
+    gold:           # Gold 레이어 (KPI / 대시보드용 집계)
+      +materialized: table
+      +schema: gold

--- a/dbt/macros/generate_schema_name.sql
+++ b/dbt/macros/generate_schema_name.sql
@@ -1,0 +1,12 @@
+{#
+  데이터셋 이름을 커스텀 스키마(+schema) 그대로 쓰게 만드는 매크로.
+  기본 dbt는 `타겟dataset_커스텀` 으로 이어붙여 silver_silver 같은 이름이 나온다.
+  이 매크로로 덮어써서 silver 폴더 → silver, gold 폴더 → gold 로 깔끔하게 나오게 한다.
+#}
+{% macro generate_schema_name(custom_schema_name, node) -%}
+    {%- if custom_schema_name is none -%}
+        {{ target.schema }}
+    {%- else -%}
+        {{ custom_schema_name | trim }}
+    {%- endif -%}
+{%- endmacro %}

--- a/dbt/models/silver/_ga4__sources.yml
+++ b/dbt/models/silver/_ga4__sources.yml
@@ -1,0 +1,16 @@
+version: 2
+
+sources:
+  - name: ga4
+    description: >
+      GA4 BigQuery Export — 메인 사이트(koreatech.in) 이벤트 스트림.
+      dev=stage.koreatech.in(analytics_427218788), prod=koreatech.in(analytics_432041405).
+      데이터셋 이름은 GA4가 자동 관리하므로 여기서 별명(ga4)으로 가린다.
+    database: "{{ env_var('KOIN_DATA_GA4_PROJECT', 'koin-stage-438512') }}"
+    schema: "{{ env_var('KOIN_DATA_GA4_DATASET', 'analytics_427218788') }}"
+    tables:
+      - name: events
+        description: >
+          일자별 GA4 이벤트. events_YYYYMMDD(확정) + events_intraday_YYYYMMDD(당일 실시간)이
+          함께 잡히므로, silver 모델에서 intraday 처리/중복 제거를 한다.
+        identifier: events_*

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -1,0 +1,22 @@
+koin_data:
+  target: "{{ env_var('DBT_TARGET', 'dev') }}"
+  outputs:
+
+    # 로컬 개발 — OAuth(gcloud ADC), 스테이지 프로젝트에 씀
+    dev:
+      type: bigquery
+      method: oauth
+      project: "{{ env_var('KOIN_DATA_GCP_PROJECT', 'koin-stage-438512') }}"
+      dataset: silver
+      location: "{{ env_var('KOIN_DATA_BIGQUERY_LOCATION', 'asia-northeast3') }}"
+      threads: 4
+
+    # 서버 운영 — 서비스 계정 키, 운영 프로젝트에 씀
+    prod:
+      type: bigquery
+      method: service-account
+      keyfile: "{{ env_var('GOOGLE_APPLICATION_CREDENTIALS', '/secrets/gcp-service-account.json') }}"
+      project: "{{ env_var('KOIN_DATA_GCP_PROJECT', 'kap-chat') }}"
+      dataset: silver
+      location: "{{ env_var('KOIN_DATA_BIGQUERY_LOCATION', 'asia-northeast3') }}"
+      threads: 4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,10 +89,14 @@ services:
     env_file:
       - path: .env
         required: false
+    environment:
+      DBT_PROFILES_DIR: /usr/app
     working_dir: /usr/app
     volumes:
       - ./dbt:/usr/app
       - ./secrets:/secrets:ro
+      # 로컬 개발용 OAuth(ADC) 인증 — 서버(prod)는 service-account 키를 쓰므로 무시됨
+      - ${HOME}/.config/gcloud:/root/.config/gcloud:ro
     command: ["--version"]
     restart: "no"
 


### PR DESCRIPTION
## Summary
Dataform을 dbt로 전환하기 위한 첫 단계 — dbt 프로젝트 뼈대 구축.

- **Medallion 구조**: `silver`(view) / `gold`(table) 레이어
- **환경 분리**: `dev`(OAuth, 스테이지) / `prod`(service-account 키, 운영), `DBT_TARGET`으로 스위칭
- **GA4 소스**: 환경변수(`KOIN_DATA_GA4_PROJECT/DATASET`)로 dev/prod 입력 스위칭. 못생긴 `analytics_*` 이름은 `ga4` 별명으로 가림
- **매크로**: `generate_schema_name` 오버라이드로 데이터셋 이름 깔끔하게 (`silver_silver` 방지)
- **docker-compose**: dbt 서비스에 `DBT_PROFILES_DIR` + 로컬 gcloud ADC 마운트

## 확인 완료
- 로컬에서 `docker compose run --rm dbt debug` → stage(`koin-stage-438512`) 연결 성공 (`All checks passed!`)

## 배포 안전성
- dbt 컨테이너는 `--version`만 실행하므로 `up` 시 자동 실행 없음
- 기존 서비스(Airflow/Superset/Postgres/Caddy) 영향 없음
- 서버 실 작동은 후속(서비스 계정 키 + 서버 `.env` prod 값 + Airflow DAG) 필요

## 남은 작업 (별도 PR)
- [ ] 첫 silver 모델 + `dbt run`
- [ ] 서버 서비스 계정 키 배치
- [ ] Airflow DAG 연동

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dbt project configuration for managing data models, macros, tests, and seeds.
  * Added GA4 BigQuery event source definitions, including daily and intraday event data.
  * Added development and production BigQuery target configurations.
  * Configured separate silver and gold data layers with appropriate output formats.

* **Chores**
  * Enabled local Google Cloud authentication for dbt workflows running in Docker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->