### PR TITLE
feat: 첫 silver 모델 silver_ga4_events (테스트)

### DIFF
--- a/dbt/models/silver/_silver__models.yml
+++ b/dbt/models/silver/_silver__models.yml
@@ -1,0 +1,20 @@
+version: 2
+
+models:
+  - name: silver_ga4_events
+    description: >
+      GA4 원본 이벤트를 정제한 silver 레이어. event_params 배열을 컬럼으로 펴고
+      타입을 변환한다. (테스트 버전 — 현재 오늘치만)
+    columns:
+      - name: event_dt
+        description: 이벤트 날짜 (event_date를 DATE로 변환)
+      - name: event_at
+        description: 이벤트 시각 (event_timestamp 마이크로초 → TIMESTAMP)
+      - name: event_name
+        description: GA4 이벤트 이름 (page_view, session_start 등)
+      - name: user_pseudo_id
+        description: GA4가 부여한 익명 유저 ID
+        tests:
+          - not_null
+      - name: page_location
+        description: 이벤트 발생 페이지 URL

--- a/dbt/models/silver/silver_ga4_events.sql
+++ b/dbt/models/silver/silver_ga4_events.sql
@@ -1,0 +1,19 @@
+-- 첫 silver 모델 (테스트): 오늘치 GA4 이벤트만 정제.
+-- GA4 원본의 event_params(배열)를 컬럼으로 펴는 게 핵심.
+-- TODO: 나중에 incremental + event_dt 파티션 table 로 확장.
+
+with source as (
+
+    select *
+    from {{ source('ga4', 'events') }}
+    where _table_suffix like '%' || format_date('%Y%m%d', current_date())   -- 오늘 (확정 + intraday)
+
+)
+
+select
+    parse_date('%Y%m%d', event_date)                                                  as event_dt,
+    timestamp_micros(event_timestamp)                                                 as event_at,
+    event_name,
+    user_pseudo_id,
+    (select value.string_value from unnest(event_params) where key = 'page_location') as page_location
+from source


### PR DESCRIPTION
## Summary
GA4 이벤트 정제 첫 silver 모델. `event_params` 배열을 컬럼으로 unnest.

- 현재 오늘치만 (테스트 버전, TODO: incremental + 파티션 확장)
- `user_pseudo_id` not_null 테스트 포함
- 로컬 stage에서 `dbt run` + `dbt test` 통과

## 목적
서버(prod)에서 dbt 파이프라인 실제 작동 + dbt docs 생성 검증용 첫 모델.

🤖 Generated with [Claude Code](https://claude.com/claude-code)