### PR TITLE
feat: Caddy로 dbt docs 서빙 준비 (dbt.bcsdlab.com)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,12 +29,14 @@ services:
         required: false
     environment:
       KOIN_DATA_SUPERSET_DOMAIN: ${KOIN_DATA_SUPERSET_DOMAIN:-localhost}
+      KOIN_DATA_DBT_DOCS_DOMAIN: ${KOIN_DATA_DBT_DOCS_DOMAIN:-localhost}
     ports:
       - "80:80"
       - "443:443"
       - "443:443/udp"
     volumes:
       - ./docker/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./dbt/target:/srv/dbt-docs:ro
       - caddy_data:/data
       - caddy_config:/config
     depends_on:

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -6,3 +6,16 @@
 		header_up X-Forwarded-Host {host}
 	}
 }
+
+# dbt docs (정적 파일). Superset과 달리 자체 로그인이 없어서 basic_auth로 막는다.
+# 계정: koin / admin1234  (해시는 `caddy hash-password`로 생성, 평문 아님)
+{$KOIN_DATA_DBT_DOCS_DOMAIN} {
+	encode gzip zstd
+
+	basic_auth {
+		koin $2a$14$ZPsoJvFZfpyeYxhFJFxlveDS7slKOlr64FKvU0dj9/pYGEXZeH926
+	}
+
+	root * /srv/dbt-docs
+	file_server
+}


### PR DESCRIPTION
## Summary
dbt docs를 `dbt.bcsdlab.com`으로 서빙하기 위한 Caddy 설정. Superset과 동일 패턴.

- `docker-compose.yml` caddy 서비스: `./dbt/target` 마운트 + `KOIN_DATA_DBT_DOCS_DOMAIN` env
- `Caddyfile`: dbt docs 블록 (`file_server` + `basic_auth`)
- docs는 Superset과 달리 자체 로그인이 없어 basic_auth로 보호 (`koin` / admin1234, bcrypt 해시)

## ⚠️ 배포 전제 (아직 배포 금지)
1. DNS: `dbt.bcsdlab.com` A레코드 → `3.39.229.133` (도메인 관리자 요청)
2. 서버 `.env`: `KOIN_DATA_DBT_DOCS_DOMAIN=dbt.bcsdlab.com` 추가
3. 서버에서 `dbt docs generate` (target/ 생성) 후 caddy 재기동

DNS 없이 배포하면 Caddy 인증서 발급 실패하므로, **DNS 확정 후 머지+배포**.

## 검증
- `caddy validate` 문법 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)