### PR TITLE
fix: use admin for dbt docs auth

### DIFF
--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -8,12 +8,12 @@
 }
 
 # dbt docs (정적 파일). Superset과 달리 자체 로그인이 없어서 basic_auth로 막는다.
-# 계정: koin / admin1234  (해시는 `caddy hash-password`로 생성, 평문 아님)
+# 계정: admin / admin1234  (해시는 `caddy hash-password`로 생성, 평문 아님)
 {$KOIN_DATA_DBT_DOCS_DOMAIN} {
 	encode gzip zstd
 
 	basic_auth {
-		koin $2a$14$ZPsoJvFZfpyeYxhFJFxlveDS7slKOlr64FKvU0dj9/pYGEXZeH926
+		admin $2a$14$ZPsoJvFZfpyeYxhFJFxlveDS7slKOlr64FKvU0dj9/pYGEXZeH926
 	}
 
 	root * /srv/dbt-docs


### PR DESCRIPTION
## What changed

- Changed the dbt Docs Basic Auth username from `koin` to `admin`.
- Updated the adjacent account comment to match.
- Kept the existing bcrypt password hash unchanged.

## Why

The intended operator account is `admin`, while the Caddy configuration expected `koin`. That mismatch causes repeated Basic Auth prompts when users enter the expected `admin` username.

## Impact

After this change is deployed, `dbt.bcsdlab.com` will accept `admin` as the Basic Auth username. The password remains unchanged.

Production still needs to pull the merged commit and recreate the Caddy container for the new configuration to take effect.

## Validation

- `git diff --check`
- Verified the staged diff contains only the Caddy username and matching comment changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated DBT documentation site access to use the `admin` login credentials.
  * Other proxy, authentication, and file-serving behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->