### PR TITLE
feat: Airflow를 airflow.bcsdlab.com 으로 노출 준비

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ x-airflow-common: &airflow-common
   environment:
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://${KOIN_DATA_POSTGRES_USER:-koin}:${KOIN_DATA_POSTGRES_PASSWORD:-change_me}@postgres:5432/${KOIN_DATA_AIRFLOW_DB:-airflow_metadata}
     AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://${KOIN_DATA_POSTGRES_USER:-koin}:${KOIN_DATA_POSTGRES_PASSWORD:-change_me}@postgres:5432/${KOIN_DATA_AIRFLOW_DB:-airflow_metadata}
+    # 프록시(Caddy) 뒤 공개 주소. 로컬은 localhost, 서버는 .env에서 https://airflow.bcsdlab.com 로 override
+    AIRFLOW__API__BASE_URL: ${KOIN_DATA_AIRFLOW_BASE_URL:-http://localhost:8080}
   volumes:
     - ./airflow/dags:/opt/airflow/dags
     - ./airflow/plugins:/opt/airflow/plugins
@@ -29,7 +31,8 @@ services:
         required: false
     environment:
       KOIN_DATA_SUPERSET_DOMAIN: ${KOIN_DATA_SUPERSET_DOMAIN:-localhost}
-      KOIN_DATA_DBT_DOCS_DOMAIN: ${KOIN_DATA_DBT_DOCS_DOMAIN:-localhost}
+      KOIN_DATA_DBT_DOCS_DOMAIN: ${KOIN_DATA_DBT_DOCS_DOMAIN:-dbt.localhost}
+      KOIN_DATA_AIRFLOW_DOMAIN: ${KOIN_DATA_AIRFLOW_DOMAIN:-airflow.localhost}
     ports:
       - "80:80"
       - "443:443"

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -19,3 +19,17 @@
 	root * /srv/dbt-docs
 	file_server
 }
+
+# Airflow (파이프라인 제어). 자체 로그인이 있지만 민감해서 basic_auth 한 겹 더 (이중 방어).
+{$KOIN_DATA_AIRFLOW_DOMAIN} {
+	encode gzip zstd
+
+	basic_auth {
+		admin $2a$14$ZPsoJvFZfpyeYxhFJFxlveDS7slKOlr64FKvU0dj9/pYGEXZeH926
+	}
+
+	reverse_proxy airflow-webserver:8080 {
+		header_up X-Forwarded-Proto {scheme}
+		header_up X-Forwarded-Host {host}
+	}
+}


### PR DESCRIPTION
## Summary
Airflow UI를 도메인(`airflow.bcsdlab.com`)으로 노출. Superset과 동일 패턴 + basic_auth.

- Caddyfile: Airflow 블록 (`reverse_proxy airflow-webserver:8080` + `basic_auth`)
- caddy 서비스: `KOIN_DATA_AIRFLOW_DOMAIN` env
- `AIRFLOW__API__BASE_URL`: 프록시 뒤 공개주소 인식 (로컬 localhost / 서버 override)
- 로컬 default 도메인 충돌 방지 (`dbt.localhost` / `airflow.localhost`)

## 보안
Airflow는 파이프라인 제어 도구라 자체 로그인 + **Caddy basic_auth 이중 방어**. (Airflow 앱 비번 강화는 후속)

## ⚠️ 배포 전제
1. DNS: `airflow.bcsdlab.com` A → `3.39.229.133`
2. 서버 `.env`: `KOIN_DATA_AIRFLOW_DOMAIN=airflow.bcsdlab.com`, `KOIN_DATA_AIRFLOW_BASE_URL=https://airflow.bcsdlab.com`

## 검증
- `caddy validate` + `docker compose config` 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to the Airflow web interface through a dedicated local domain.
  * Protected the Airflow interface with basic authentication.
  * Enabled compressed responses for improved loading performance.

* **Configuration**
  * Added support for configuring the Airflow and dbt documentation domains.
  * Improved proxy handling for Airflow requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->