### PR TITLE
fix: Airflow Caddy basic_auth 제거 (반복 팝업 해결)

### DIFF
--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -20,13 +20,11 @@
 	file_server
 }
 
-# Airflow (파이프라인 제어). 자체 로그인이 있지만 민감해서 basic_auth 한 겹 더 (이중 방어).
+# Airflow (파이프라인 제어). 자체 로그인이 있어서 Caddy basic_auth는 뺀다.
+# (basic_auth + Airflow API의 401이 겹치면 브라우저가 비번 팝업을 계속 띄우는 문제)
+# 보안은 Airflow 자체 로그인 + 강한 비번으로. 필요시 FabAuthManager로 강화.
 {$KOIN_DATA_AIRFLOW_DOMAIN} {
 	encode gzip zstd
-
-	basic_auth {
-		admin $2a$14$ZPsoJvFZfpyeYxhFJFxlveDS7slKOlr64FKvU0dj9/pYGEXZeH926
-	}
 
 	reverse_proxy airflow-webserver:8080 {
 		header_up X-Forwarded-Proto {scheme}


### PR DESCRIPTION
Airflow 자체 로그인이 있어 basic_auth의 401과 Airflow API의 401이 겹쳐 브라우저가 비번 팝업을 반복 표시하는 문제. Caddy basic_auth 제거하고 Airflow 로그인에 의존. dbt docs(정적, 자체로그인 없음)의 basic_auth는 유지.