### PR TITLE
fix: silver_events 클러스터 순서 event_name 우선

### DIFF
--- a/dbt/models/silver/silver_events.sql
+++ b/dbt/models/silver/silver_events.sql
@@ -3,7 +3,7 @@
     materialized='incremental',
     incremental_strategy='insert_overwrite',
     partition_by={'field': 'event_dt', 'data_type': 'date'},
-    cluster_by=['user_pseudo_id', 'event_name']
+    cluster_by=['event_name', 'user_pseudo_id']
   )
 }}
 


### PR DESCRIPTION
이벤트 타입 필터가 잦은 쿼리 패턴에 맞춰 cluster_by를 `[event_name, user_pseudo_id]`로. 다음 full-refresh 때 적용.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved event data organization to support more efficient querying and retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->