### PR TITLE
refactor: remove unused raw delivery id

### DIFF
--- a/dbt/models/silver/silver_events_temp.sql
+++ b/dbt/models/silver/silver_events_temp.sql
@@ -145,23 +145,7 @@ raw_keyed as (
     select
         source_payload_canonicalized.*,
         -- 완전히 같은 canonical raw payload만 물리 중복으로 제거한다.
-        to_hex(sha256(canonical_payload_json)) as raw_event_id,
-        -- GA4 전송·배치 키는 유일성을 보장하지 않으므로 계보·진단 용도로만 보존한다.
-        to_hex(
-            sha256(
-                to_json_string(
-                    struct(
-                        raw_event.stream_id as stream_id,
-                        raw_event.user_pseudo_id as user_pseudo_id,
-                        raw_event.event_bundle_sequence_id as event_bundle_sequence_id,
-                        raw_event.event_server_timestamp_offset as event_server_timestamp_offset,
-                        raw_event.batch_page_id as batch_page_id,
-                        raw_event.batch_ordering_id as batch_ordering_id,
-                        raw_event.batch_event_index as batch_event_index
-                    )
-                )
-            )
-        ) as raw_delivery_id
+        to_hex(sha256(canonical_payload_json)) as raw_event_id
     from source_payload_canonicalized
 
 ),
@@ -199,7 +183,6 @@ bronze_deduped as (
         partition by raw_event_id
         order by
             canonical_payload_json,
-            raw_delivery_id,
             source_table_suffix
     ) = 1
 


### PR DESCRIPTION
## 변경 사항

- `silver_events_temp`의 `raw_delivery_id` 생성 로직을 제거합니다.
- `bronze_deduped`의 대표 행 정렬에서 `raw_delivery_id` 참조를 제거합니다.

## 배경

`raw_event_id`는 canonical 전체 원천 payload를 기반으로 물리 중복을 제거하고, Bronze 원천 행을 식별하는 역할을 이미 수행합니다. `raw_delivery_id`는 최종 Silver 스키마에 출력되지 않고 테스트나 downstream에서도 사용되지 않으며, 동일 `raw_event_id` 그룹 안에서는 정렬 기준으로도 실질적인 차이를 만들지 않습니다.

## 영향

- 최종 Silver 스키마 변경 없음
- `raw_event_id` 기반 물리 중복 제거 방식 변경 없음
- `event_id` 기반 논리 중복 제거 방식 변경 없음
- 불필요한 JSON 직렬화와 SHA256 계산 제거

## 검증

- 저장소 전체 `raw_delivery_id` 잔여 참조 없음
- `git diff --check` 통과
- 변경 범위가 한 SQL 파일의 미사용 계산·정렬 참조 제거로 제한됨
- 현재 실행 환경에 dbt CLI와 Docker가 없어 `dbt parse/compile`은 실행하지 못함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event deduplication consistency by using canonical event data as the primary matching criterion.
  * Reduced the chance of duplicate or inconsistently selected event records caused by delivery metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->