### PR TITLE
refactor: derive raw event id from delivery metadata and params

### DIFF
--- a/dbt/models/silver/_silver_events_temp.yml
+++ b/dbt/models/silver/_silver_events_temp.yml
@@ -8,7 +8,7 @@ models:
       공통 이벤트 파라미터·KST 시간·화면명·Android 가입 세션을 표준화한다.
     columns:
       - name: raw_event_id
-        description: event_params를 타입·키 기준으로 정렬한 전체 원천 payload의 SHA256 식별자. 배열 순서만 다른 동일 payload는 같은 값이 된다.
+        description: 전송·배치 위치, user_pseudo_id, canonical event_params로 생성한 원천 물리 행의 SHA256 식별자
         data_tests:
           - not_null
           - unique

--- a/dbt/models/silver/silver_events_temp.sql
+++ b/dbt/models/silver/silver_events_temp.sql
@@ -105,7 +105,7 @@ source_filtered as (
 
 ),
 
--- event_id 해시에서는 값 타입과 무관한 문자열 변환을 하지 않는다.
+-- raw_event_id와 event_id 해시에서는 값 타입과 무관한 문자열 변환을 하지 않는다.
 source_canonicalized as (
 
     select
@@ -140,13 +140,33 @@ source_payload_canonicalized as (
 
 ),
 
-raw_keyed as (
+-- 전송·배치 위치와 canonical event_params를 raw event의 물리 식별 정보로 사용한다.
+raw_identity_prepared as (
 
     select
         source_payload_canonicalized.*,
-        -- 완전히 같은 canonical raw payload만 물리 중복으로 제거한다.
-        to_hex(sha256(canonical_payload_json)) as raw_event_id
+        to_json_string(
+            struct(
+                raw_event.stream_id as stream_id,
+                raw_event.user_pseudo_id as user_pseudo_id,
+                raw_event.event_bundle_sequence_id as event_bundle_sequence_id,
+                raw_event.event_server_timestamp_offset as event_server_timestamp_offset,
+                raw_event.batch_page_id as batch_page_id,
+                raw_event.batch_ordering_id as batch_ordering_id,
+                raw_event.batch_event_index as batch_event_index,
+                canonical_event_params as event_params
+            )
+        ) as raw_identity_json
     from source_payload_canonicalized
+
+),
+
+raw_keyed as (
+
+    select
+        raw_identity_prepared.*,
+        to_hex(sha256(raw_identity_json)) as raw_event_id
+    from raw_identity_prepared
 
 ),
 
@@ -154,22 +174,22 @@ raw_key_stats as (
 
     select
         raw_event_id,
-        count(distinct canonical_payload_json) as payload_variant_count
+        count(distinct raw_identity_json) as raw_identity_variant_count
     from raw_keyed
     group by raw_event_id
 
 ),
 
--- 같은 raw_event_id가 서로 다른 payload를 가리키면 제거하지 않고 모델을 실패시킨다.
+-- 같은 해시가 서로 다른 raw identity를 가리키면 제거하지 않고 모델을 실패시킨다.
 raw_validated as (
 
     select raw_keyed.*
     from raw_keyed
     inner join raw_key_stats using (raw_event_id)
     where if(
-        payload_variant_count = 1,
+        raw_identity_variant_count = 1,
         true,
-        error(format('raw_event_id %s maps to multiple payloads', raw_event_id))
+        error(format('raw_event_id %s maps to multiple raw identities', raw_event_id))
     )
 
 ),


### PR DESCRIPTION
## 변경 사항

- `raw_event_id`를 전송·배치 위치, `user_pseudo_id`, canonical `event_params`의 SHA256으로 생성합니다.
- 해시 충돌 검증도 전체 payload가 아닌 새 `raw_identity_json` 원문을 기준으로 수행합니다.
- `raw_event_id` 컬럼 설명을 새 공식에 맞게 수정합니다.

## 배경

2026-05-30~31 원천 데이터를 비교한 결과, 새 공식은 구 raw 중복 448개 그룹을 모두 식별했지만 현재 full-payload 공식은 54개만 식별했습니다. 나머지 394개 그룹은 실제 `user_properties` 내용은 같고 배열 순서만 달라 full-payload 해시가 갈린 경우였습니다.

## 영향

- Silver 최종 컬럼 구성은 변하지 않습니다.
- 전체 이력의 `raw_event_id` 값은 새 공식으로 다시 생성됩니다.
- 동일한 전송·배치 위치와 canonical `event_params`를 가진 행은 Bronze 단계에서 하나로 축약됩니다.

## 배포 주의사항

- 기본 증분 실행은 최근 파티션만 교체하므로, 병합 후 전체 기간 백필이 필요합니다.
- 전체 기간을 다시 계산하지 않으면 과거 파티션에는 구 공식, 최근 파티션에는 새 공식의 `raw_event_id`가 함께 남습니다.

## 검증

- 원격 dbt 1.9.0 / dbt-bigquery 1.9.0에서 `dbt compile --select silver_events_temp` 통과
- `start_date=20260530`, `end_date=20260531`로 `dbt show --select silver_events_temp` 실행 성공
- 비교 조회 결과: 새 공식 448개 중복 그룹, 기존 full-payload 공식 54개 중복 그룹
- 차이 394개 그룹은 모두 `user_properties` 배열 순서만 다름
- `git diff --check` 통과

## 의존성

- #23 위에 쌓은 PR입니다. #23 병합 후 base를 `main`으로 변경합니다.
