### PR TITLE
fix: inherit signup session id from latest start

### DIFF
--- a/dbt/models/silver/_silver_events_temp.yml
+++ b/dbt/models/silver/_silver_events_temp.yml
@@ -46,7 +46,7 @@ models:
         description: event_params에서 추출한 GA4 세션 식별자
 
       - name: custom_session_id
-        description: 원본 값을 우선하고 Android 회원가입 이벤트는 15분 규칙으로 보정한 세션 식별자
+        description: 원본 값을 우선하고 Android 회원가입 이벤트는 최근 시작 ID 상속 또는 15분 생성 규칙으로 보정한 세션 식별자
 
       - name: platform
         description: 이벤트 발생 플랫폼(WEB, ANDROID, IOS 등)

--- a/dbt/models/silver/silver_events_temp.sql
+++ b/dbt/models/silver/silver_events_temp.sql
@@ -441,7 +441,14 @@ signup_candidates as (
     select
         staged.*,
         last_value(
-            if(staged.signup_stage = 'signup_start', staged.event_ts, null) ignore nulls
+            if(
+                staged.signup_stage = 'signup_start',
+                struct(
+                    staged.event_ts as anchor_event_ts,
+                    staged.custom_session_id as anchor_custom_session_id
+                ),
+                null
+            ) ignore nulls
         ) over (
             partition by staged.user_pseudo_id
             order by
@@ -451,53 +458,58 @@ signup_candidates as (
                 coalesce(staged.batch_event_index, -1),
                 staged.event_id
             rows between unbounded preceding and current row
-        ) as anchor_start_event_ts
+        ) as anchor_start
     from signup_stage as staged
     where staged.platform = 'ANDROID'
-      and staged.custom_session_id is null
       and staged.user_pseudo_id is not null
       and staged.signup_stage is not null
 
 ),
 
--- 기존 Dataform과 동일하게 가입 시작 시각의 KST DATETIME 문자열로 보정 ID를 만든다.
 signup_candidates_localized as (
 
     select
-        signup_candidates.*,
+        signup_candidates.* except (anchor_start),
+        anchor_start.anchor_event_ts as anchor_start_event_ts,
+        anchor_start.anchor_custom_session_id as anchor_custom_session_id,
         datetime(
-            timestamp_micros(anchor_start_event_ts),
+            timestamp_micros(anchor_start.anchor_event_ts),
             'Asia/Seoul'
         ) as anchor_start_at
     from signup_candidates
 
 ),
 
-generated_signup_sessions as (
+-- 최신 가입 시작의 기존 ID를 우선 상속하고, 없을 때만 Dataform 호환 ID를 생성한다.
+signup_session_fills as (
 
     select
         event_id,
-        concat(
-            'sign_up_strict_',
-            cast(unix_seconds(timestamp(anchor_start_at)) as string),
-            '_',
-            upper(
-                substr(
-                    to_hex(
-                        md5(
-                            concat(
-                                user_pseudo_id,
-                                cast(anchor_start_at as string)
+        coalesce(
+            anchor_custom_session_id,
+            concat(
+                'sign_up_strict_',
+                cast(unix_seconds(timestamp(anchor_start_at)) as string),
+                '_',
+                upper(
+                    substr(
+                        to_hex(
+                            md5(
+                                concat(
+                                    user_pseudo_id,
+                                    cast(anchor_start_at as string)
+                                )
                             )
-                        )
-                    ),
-                    1,
-                    5
+                        ),
+                        1,
+                        5
+                    )
                 )
             )
-        ) as generated_custom_session_id
+        ) as filled_custom_session_id
     from signup_candidates_localized
-    where anchor_start_event_ts is not null
+    where custom_session_id is null
+      and anchor_start_event_ts is not null
       and event_ts between anchor_start_event_ts and anchor_start_event_ts + (15 * 60 * 1000000)
 
 ),
@@ -514,10 +526,10 @@ signup_sessionized as (
         ),
         coalesce(
             staged.custom_session_id,
-            generated_signup_sessions.generated_custom_session_id
+            signup_session_fills.filled_custom_session_id
         ) as custom_session_id
     from signup_stage as staged
-    left join generated_signup_sessions using (event_id)
+    left join signup_session_fills using (event_id)
 
 ),
 


### PR DESCRIPTION
## 변경 내용

- Android 가입 단계 이벤트의 최근 `signup_start`를 찾을 때 기존 `custom_session_id` 보유 행도 윈도우 입력에 포함합니다.
- 후속 이벤트의 `custom_session_id`가 비어 있으면 최근 `signup_start`의 ID를 우선 상속합니다.
- 시작 이벤트에도 ID가 없을 때만 기존 `sign_up_strict_*` 생성 규칙을 사용합니다.
- 이미 존재하는 `custom_session_id`와 `raw_event_id` 생성 로직은 변경하지 않습니다.

## 원인

기존 로직은 윈도우 계산 전에 `custom_session_id is null` 조건을 적용했습니다. 그 결과 ID가 이미 있는 `signup_start` 행이 윈도우에서 제외되어, 뒤따르는 가입 이벤트가 해당 세션 ID를 상속하지 못했습니다.

## 검증

BigQuery 전체 원천 범위(`2024-07-11`~`2026-07-22`)에서 수정 SQL을 컴파일하고 읽기 전용 감사 쿼리로 검증했습니다.

- 원천 행: 19,274,800
- Silver/피벗/세션화/최종 행: 모두 19,170,395
- 보정 행: 2,894
  - 기존 시작 ID 상속: 2,469행 / 391개 ID
  - 기존 규칙으로 신규 생성: 425행 / 82개 시작 세션
- 상속 ID 불일치: 0
- 기존 ID 덮어쓰기: 0
- 상속 가능한데 미보정된 행: 0
- 유효한 시작점이 없어 남은 NULL 가입 단계 이벤트: 42
- 최종 `event_id` 중복: 0
- 최종 `raw_event_id` 중복: 0

문제일 `2025-10-29`에 대한 `dbt show`도 성공했습니다.

## 반영 메모

이 수정은 다음 Silver 전체 갱신에 함께 포함해야 합니다. 이번 PR 자체에서는 테이블 전체 갱신을 실행하지 않았습니다.
