### PR TITLE
fix: GA4 소스 기본값을 stage로 되돌림

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,5 +34,6 @@ DBT_TARGET=dev
 GOOGLE_APPLICATION_CREDENTIALS=/secrets/gcp-service-account.json
 KOIN_DATA_GCP_PROJECT=your-gcp-project
 KOIN_DATA_BIGQUERY_LOCATION=asia-northeast3
-KOIN_DATA_GA4_PROJECT=kap-chat
-KOIN_DATA_GA4_DATASET=analytics_432041405
+# GA4 입력 소스 — 기본은 stage. 운영(kap-chat/analytics_432041405)은 서버 .env에서만 명시한다.
+KOIN_DATA_GA4_PROJECT=koin-stage-438512
+KOIN_DATA_GA4_DATASET=analytics_427218788

--- a/dbt/models/silver/_ga4__sources.yml
+++ b/dbt/models/silver/_ga4__sources.yml
@@ -3,11 +3,13 @@ version: 2
 sources:
   - name: ga4
     description: >
-      GA4 BigQuery Export — 메인 사이트(koreatech.in) production 이벤트 스트림.
-      기본 원본은 kap-chat.analytics_432041405이며, 다른 환경은 환경변수로 재정의한다.
+      GA4 BigQuery Export — 메인 사이트(koreatech.in) 이벤트 스트림.
+      기본 원본은 stage(koin-stage-438512.analytics_427218788)이며,
+      운영(kap-chat.analytics_432041405)은 환경변수로 명시할 때만 읽는다.
+      환경변수를 깜빡해도 운영 데이터를 읽지 않도록 기본값을 stage로 둔다.
       데이터셋 이름은 GA4가 자동 관리하므로 여기서 별명(ga4)으로 가린다.
-    database: "{{ env_var('KOIN_DATA_GA4_PROJECT', 'kap-chat') }}"
-    schema: "{{ env_var('KOIN_DATA_GA4_DATASET', 'analytics_432041405') }}"
+    database: "{{ env_var('KOIN_DATA_GA4_PROJECT', 'koin-stage-438512') }}"
+    schema: "{{ env_var('KOIN_DATA_GA4_DATASET', 'analytics_427218788') }}"
     tables:
       - name: events
         description: >


### PR DESCRIPTION
## 배경

PR #22에서 GA4 source 기본값이 stage → prod로 변경됐습니다.
프로덕션 검증 모델(`silver_events_temp`)을 운영 데이터로 확인하려는 의도는 이해되지만,
**환경변수를 깜빡한 환경이 운영 GA4를 읽게 되는** 문제가 있습니다.

## 문제

`.env` 없이 `dbt run`을 돌리면:

```
운영 GA4에서 읽어서  →  stage에 테이블 생성
(kap-chat)              (koin-stage-438512)
```

- 운영 데이터가 stage로 복사됨 (데이터 거버넌스)
- 운영 데이터셋 스캔 비용 발생
- 출력이 stage라 **본인은 안전하게 돌린 줄 착각**하게 됨

> 운영에 **쓰는** 사고는 아닙니다. 출력은 `profiles.yml`이 정하고 기본이 `dev`이며,
> 로컬엔 운영 서비스계정 키가 없어 이중으로 막혀 있습니다. 이번 건은 **읽기 기본값**만의 문제입니다.

## 변경

- `_ga4__sources.yml`: 기본값 `kap-chat`/`analytics_432041405` → `koin-stage-438512`/`analytics_427218788`
- `.env.example`: 견본도 stage 값으로. 운영은 서버 `.env`에서만 명시
- 기본값을 stage로 두는 이유를 source description에 명시

운영 검증이 필요하면 환경변수로 **명시적으로** 전환합니다 (safe-by-default).
#22에서 보강된 intraday 설명은 그대로 유지했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated default GA4 data sources to use the staging environment.
  * Production GA4 values are now selected only when explicitly configured.
  * Added guidance clarifying the default GA4 input environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->