### PR TITLE
feat: Airflow(Cosmos)로 dbt 오케스트레이션

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,9 @@ AIRFLOW__CORE__LOAD_EXAMPLES=false
 AIRFLOW__WEBSERVER__EXPOSE_CONFIG=false
 AIRFLOW__WEBSERVER__SECRET_KEY=change_me
 # Execution API(JWT) 서명 키. scheduler와 api-server가 같은 값을 써야 task가 실행된다.
-KOIN_DATA_AIRFLOW_JWT_SECRET=change_me
+# 필수값이며 기본값이 없다. 비어 있으면 Airflow 컨테이너가 뜨지 않는다.
+# 생성: openssl rand -base64 32
+KOIN_DATA_AIRFLOW_JWT_SECRET=replace-with-generated-secret
 
 # Superset
 KOIN_DATA_SUPERSET_DOMAIN=superset.bcsdlab.com

--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,9 @@ SUPERSET_ADMIN_EMAIL=admin@example.com
 
 # BigQuery/dbt
 DBT_TARGET=dev
-GOOGLE_APPLICATION_CREDENTIALS=/secrets/gcp-service-account.json
+# prod 서비스계정 키 경로. 모든 컨테이너가 ./secrets를 /secrets로 마운트하므로
+# 이 기본값이 그대로 맞다. 로컬(dev)은 OAuth를 쓰니 주석 유지.
+# GOOGLE_APPLICATION_CREDENTIALS=/secrets/gcp-service-account.json
 KOIN_DATA_GCP_PROJECT=your-gcp-project
 KOIN_DATA_BIGQUERY_LOCATION=asia-northeast3
 # GA4 입력 소스 — 기본은 stage. 운영(kap-chat/analytics_432041405)은 서버 .env에서만 명시한다.

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@ AIRFLOW__CORE__EXECUTOR=LocalExecutor
 AIRFLOW__CORE__LOAD_EXAMPLES=false
 AIRFLOW__WEBSERVER__EXPOSE_CONFIG=false
 AIRFLOW__WEBSERVER__SECRET_KEY=change_me
+# Execution API(JWT) 서명 키. scheduler와 api-server가 같은 값을 써야 task가 실행된다.
+KOIN_DATA_AIRFLOW_JWT_SECRET=change_me
 
 # Superset
 KOIN_DATA_SUPERSET_DOMAIN=superset.bcsdlab.com

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -1,21 +1,85 @@
-# KOIN_DATA - Airflow DAG 관리
+# Airflow
 
-KOIN 서비스의 데이터 파이프라인을 위한 Apache Airflow DAG 코드 저장소
+GA4 → BigQuery 데이터 파이프라인을 오케스트레이션한다.
+dbt 모델 실행은 [Cosmos](https://astronomer.github.io/astronomer-cosmos/)가 담당한다.
 
----
-
-## 📁 폴더 구조
+## 폴더 구조
 
 ```
-KOIN_DATA/
-└── airflow/
-    ├── dags/
-    │   └── koin/
-    │       ├── archive_dag/     # 더 이상 사용하지 않는 DAG 파일 보관
-    │       ├── archive_query/   # 더 이상 사용하지 않는 쿼리 파일 보관
-    │       ├── query/           # 현재 DAG에서 사용 중인 SQL 쿼리 파일
-    │       └── *.py             # 실행 중인 DAG 파일
-    └── sensors/                 # Airflow Sensor DAG 파일
+airflow/
+├── dags/            # DAG 파일 (평평하게 둔다)
+│   └── dbt_ga4_daily.py
+├── plugins/         # Airflow 플러그인
+└── logs/            # 런타임 산출물, Git에 커밋하지 않는다
 ```
 
+DAG가 10개를 넘어가면 그때 그룹핑을 검토한다. Airflow는 `dags/` 아래를 재귀적으로
+탐색하고 DAG의 정체성은 파일 경로가 아니라 `dag_id`이므로, 나중에 폴더로 옮겨도
+실행 이력은 유지된다.
 
+## 네이밍 컨벤션
+
+### DAG
+
+```
+{action}_{domain}_{schedule}     예) dbt_ga4_daily
+```
+
+| 요소 | 값 |
+| --- | --- |
+| action | `dbt` / `ingest` / `dq` / `refresh` |
+| domain | 데이터 도메인 (`ga4`, `userdb` 등) |
+| schedule | `daily` / `hourly` 등 |
+
+- 레이어(silver/gold)는 **DAG 이름이 아니라 task 이름**에 드러낸다.
+  한 DAG가 silver와 gold를 함께 만들 수 있기 때문이다.
+- DAG를 나누는 기준은 **스케줄과 의존성**이다. 같은 주기로 돌고 `ref()`로 이어지면
+  한 DAG에 두어 Cosmos가 순서를 그리게 하고, 무관하면 나눈다.
+
+### Task
+
+Cosmos가 dbt 모델 이름을 그대로 task 이름으로 쓴다 (`silver_events.run`,
+`silver_events.test`). 별도로 만드는 task는 `{동사}_{대상}` 형태로 둔다
+(`refresh_superset` 등).
+
+## dbt 실행 구조
+
+Airflow 컨테이너 안에서 세 조각이 맞물린다.
+
+| 위치 | 내용 | 반영 방법 |
+| --- | --- | --- |
+| `/home/airflow/dbt-venv` | dbt 실행 파일 (격리 venv) | 이미지 빌드 |
+| `/opt/airflow/dbt` | dbt 프로젝트 (`./dbt` 마운트) | 파일 수정 즉시 |
+| `/opt/airflow/dags` | DAG (`./airflow/dags` 마운트) | 파일 수정 즉시 |
+
+dbt는 Airflow 본체와 파이썬 라이브러리를 공유하지 않도록 별도 venv에 설치해
+이미지에 굽는다. Cosmos는 이 venv의 dbt를 `InvocationMode.SUBPROCESS`로 호출한다.
+
+## 날짜 처리
+
+처리 날짜는 **항상 Airflow가 정하고** dbt에 `--vars`로 넘긴다.
+
+| 실행 | 범위 |
+| --- | --- |
+| 스케줄 | `data_interval_start` 기준 최근 3일 |
+| 수동 (Trigger DAG w/ config) | conf로 넘긴 `start_date` ~ `end_date` |
+
+GA4는 확정 데이터를 며칠에 걸쳐 갱신하므로 매 실행 최근 3일을 다시 만든다.
+모델이 `insert_overwrite`라 파티션이 통째로 교체되어 추가뿐 아니라 삭제·변경도 반영된다.
+
+전체 적재(분석 시작일 `20240711`부터)도 수동 실행으로 날짜를 명시해서 돌린다.
+2년치 스캔이 실수로 발생하지 않도록 자동 분기를 두지 않는다.
+
+```json
+{"start_date": "20240711", "end_date": "20260725"}
+```
+
+## 접속
+
+| 환경 | 주소 |
+| --- | --- |
+| 로컬 | `https://airflow.localhost` |
+| 서버 | `https://airflow.bcsdlab.com` |
+
+`http://localhost:8080` 직통은 인증 토큰이 실리지 않아 로그인이 반복된다.
+반드시 https(Caddy)로 접속한다.

--- a/airflow/dags/dbt_ga4_daily.py
+++ b/airflow/dags/dbt_ga4_daily.py
@@ -64,15 +64,30 @@ LOOKBACK_DAYS = 3
 #   * 스케줄 실행: 담당 구간(data_interval_start) 기준 최근 LOOKBACK_DAYS일
 #   * 수동 실행  : Trigger DAG w/ config로 넘긴 날짜를 그대로 사용
 #       {"start_date": "20240711", "end_date": "20260725"}   ← 전체 적재도 이렇게
-# dag_run.conf가 없는 스케줄 실행에서도 안전하도록 conf 자체를 or로 감싼다.
-CONF = "(dag_run.conf or {})"
+#
+# conf에 날짜가 하나라도 있으면 두 값 모두 conf에서만 읽는다. 한쪽만 넣었을 때
+# 나머지를 자동값으로 채우면 의도하지 않은 범위(예: 2년치)가 조용히 돌 수 있어,
+# 빈 값을 그대로 넘겨 모델의 "둘 다 지정" 검증에서 실패하게 만든다.
+#
+# dag_run.conf는 스케줄 실행에서 None이므로 or {} 로 감싼다.
 DATE_VARS = {
     "start_date": (
-        "{{ %s.get('start_date')"
-        " or (data_interval_start - macros.timedelta(days=%d)) | ds_nodash }}"
-        % (CONF, LOOKBACK_DAYS)
+        "{% set conf = dag_run.conf or {} %}"
+        "{% if conf.get('start_date') or conf.get('end_date') %}"
+        "{{ conf.get('start_date', '') }}"
+        "{% else %}"
+        "{{ (data_interval_start - macros.timedelta(days=" + str(LOOKBACK_DAYS) + "))"
+        " | ds_nodash }}"
+        "{% endif %}"
     ),
-    "end_date": "{{ %s.get('end_date') or data_interval_start | ds_nodash }}" % CONF,
+    "end_date": (
+        "{% set conf = dag_run.conf or {} %}"
+        "{% if conf.get('start_date') or conf.get('end_date') %}"
+        "{{ conf.get('end_date', '') }}"
+        "{% else %}"
+        "{{ data_interval_start | ds_nodash }}"
+        "{% endif %}"
+    ),
 }
 
 dbt_ga4_daily = DbtDag(

--- a/airflow/dags/dbt_ga4_daily.py
+++ b/airflow/dags/dbt_ga4_daily.py
@@ -13,11 +13,16 @@ Cosmos가 dbt 프로젝트를 읽어 모델 하나하나를 Airflow task로 변�
 from __future__ import annotations
 
 import os
+import re
 from datetime import timedelta
+from typing import Any
 
 import pendulum
+from airflow.providers.standard.operators.python import PythonOperator
 from cosmos import DbtDag, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.constants import InvocationMode, TestBehavior
+
+DATE_PATTERN = re.compile(r"^\d{8}$")
 
 DBT_PROJECT_DIR = "/opt/airflow/dbt"
 
@@ -101,6 +106,37 @@ DATE_VARS = {
     ),
 }
 
+
+def validate_conf_dates(dag_run: Any = None, **_: Any) -> None:
+    """수동 실행으로 넘어온 날짜를 dbt에 전달하기 전에 검증한다.
+
+    두 값은 모델에서 SQL 리터럴로 삽입되므로 형식이 어긋나면 여기서 끊는다.
+    모델도 같은 검증을 하지만(CLI로 직접 실행하는 경로가 있으므로),
+    DAG에서 먼저 막아 잘못된 범위로 BigQuery를 스캔하지 않게 한다.
+    """
+    conf = (dag_run.conf if dag_run else None) or {}
+    start_date, end_date = conf.get("start_date"), conf.get("end_date")
+
+    if not start_date and not end_date:
+        return  # 스케줄 실행. 날짜는 Airflow가 계산한다.
+
+    if not (start_date and end_date):
+        raise ValueError(
+            "start_date와 end_date는 반드시 함께 지정해야 합니다. "
+            f"받은 conf: {conf!r}"
+        )
+
+    for key, value in (("start_date", start_date), ("end_date", end_date)):
+        if not DATE_PATTERN.match(str(value)):
+            raise ValueError(
+                f"{key}는 숫자 8자리(YYYYMMDD)여야 합니다. 받은 값: {value!r}"
+            )
+
+    if str(start_date) > str(end_date):
+        raise ValueError(
+            f"start_date({start_date})가 end_date({end_date})보다 늦을 수 없습니다."
+        )
+
 dbt_ga4_daily = DbtDag(
     dag_id="dbt_ga4_daily",
     project_config=project_config,
@@ -119,3 +155,15 @@ dbt_ga4_daily = DbtDag(
     tags=["dbt", "ga4", "silver"],
     doc_md=__doc__,
 )
+
+# Cosmos가 만든 dbt task들 앞에 날짜 검증을 세운다.
+# roots는 검증 task를 추가하기 전에 잡아둔다.
+_dbt_root_tasks = list(dbt_ga4_daily.roots)
+
+with dbt_ga4_daily:
+    validate_dates = PythonOperator(
+        task_id="validate_dates",
+        python_callable=validate_conf_dates,
+    )
+    for _root in _dbt_root_tasks:
+        validate_dates >> _root

--- a/airflow/dags/dbt_ga4_daily.py
+++ b/airflow/dags/dbt_ga4_daily.py
@@ -60,8 +60,16 @@ render_config = RenderConfig(
 # insert_overwrite라 파티션이 통째로 교체되어 삭제·변경까지 반영된다.
 LOOKBACK_DAYS = 3
 
+# GA4 확정 export는 전날까지만 존재하므로 오늘은 처리하지 않는다.
+#
+# 주의: Airflow 3에서 cron 문자열은 CronTriggerTimetable을 쓰며,
+# data_interval_start는 "직전 구간의 시작"이 아니라 실행 시각 그 자체다
+# (data_interval 길이가 0). 따라서 어제를 얻으려면 직접 1일을 빼야 한다.
+OFFSET_DAYS = 1
+
 # 처리 날짜는 항상 Airflow가 정한다.
-#   * 스케줄 실행: 담당 구간(data_interval_start) 기준 최근 LOOKBACK_DAYS일
+#   * 스케줄 실행: 실행일 기준 어제까지의 최근 LOOKBACK_DAYS일
+#                 (7/26 09:00 실행 → 20260723 ~ 20260725)
 #   * 수동 실행  : Trigger DAG w/ config로 넘긴 날짜를 그대로 사용
 #       {"start_date": "20240711", "end_date": "20260725"}   ← 전체 적재도 이렇게
 #
@@ -76,8 +84,9 @@ DATE_VARS = {
         "{% if conf.get('start_date') or conf.get('end_date') %}"
         "{{ conf.get('start_date', '') }}"
         "{% else %}"
-        "{{ (data_interval_start - macros.timedelta(days=" + str(LOOKBACK_DAYS) + "))"
-        " | ds_nodash }}"
+        "{{ (data_interval_start - macros.timedelta(days="
+        + str(OFFSET_DAYS + LOOKBACK_DAYS - 1)
+        + ")) | ds_nodash }}"
         "{% endif %}"
     ),
     "end_date": (
@@ -85,7 +94,9 @@ DATE_VARS = {
         "{% if conf.get('start_date') or conf.get('end_date') %}"
         "{{ conf.get('end_date', '') }}"
         "{% else %}"
-        "{{ data_interval_start | ds_nodash }}"
+        "{{ (data_interval_start - macros.timedelta(days="
+        + str(OFFSET_DAYS)
+        + ")) | ds_nodash }}"
         "{% endif %}"
     ),
 }

--- a/airflow/dags/dbt_ga4_daily.py
+++ b/airflow/dags/dbt_ga4_daily.py
@@ -1,0 +1,95 @@
+"""GA4 이벤트를 silver 레이어로 적재하는 일일 dbt 파이프라인.
+
+Cosmos가 dbt 프로젝트를 읽어 모델 하나하나를 Airflow task로 변환한다.
+모델 간 ref() 의존성이 곧 task 순서가 되고, 각 모델의 dbt test는
+해당 모델 바로 뒤에 붙는다(TestBehavior.AFTER_EACH).
+
+구성 요소가 컨테이너 안 세 곳에 나뉘어 있다.
+  - dbt 실행 파일: /home/airflow/dbt-venv/bin/dbt  (이미지에 구운 격리 venv)
+  - dbt 프로젝트 : /opt/airflow/dbt                 (호스트 ./dbt 마운트)
+  - 이 DAG       : /opt/airflow/dags                (호스트 ./airflow/dags 마운트)
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+
+import pendulum
+from cosmos import DbtDag, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
+from cosmos.constants import InvocationMode, TestBehavior
+
+DBT_PROJECT_DIR = "/opt/airflow/dbt"
+
+# Airflow 본체와 라이브러리를 섞지 않기 위해 dbt는 별도 venv에 격리해 두었다.
+# Cosmos 실행 모드는 LOCAL이지만, 실행 파일이 이 venv를 가리키므로 의존성은 분리된다.
+# (Cosmos의 VIRTUALENV 모드와 달리 런타임 설치가 없어 빠르고 재현 가능하다.)
+DBT_EXECUTABLE = "/home/airflow/dbt-venv/bin/dbt"
+
+# 출력 대상은 DBT_TARGET 환경변수가 정한다. 로컬은 dev(stage), 서버는 prod.
+DBT_TARGET = os.getenv("DBT_TARGET", "dev")
+
+profile_config = ProfileConfig(
+    profile_name="koin_data",
+    target_name=DBT_TARGET,
+    profiles_yml_filepath=f"{DBT_PROJECT_DIR}/profiles.yml",
+)
+
+project_config = ProjectConfig(
+    dbt_project_path=DBT_PROJECT_DIR,
+    # packages.yml이 없고 컨테이너에 git도 없으므로 dbt deps를 건너뛴다.
+    install_dbt_deps=False,
+)
+
+execution_config = ExecutionConfig(
+    dbt_executable_path=DBT_EXECUTABLE,
+    # 기본값 DBT_RUNNER는 dbt를 라이브러리로 import해 같은 프로세스에서 돌리므로
+    # Airflow 본체에 dbt가 설치돼 있어야 한다. 격리 venv를 쓰려면 별도 프로세스로 실행한다.
+    invocation_mode=InvocationMode.SUBPROCESS,
+)
+
+render_config = RenderConfig(
+    # 모델 실행 직후 해당 모델의 test를 돌린다. dbt build와 같은 흐름.
+    test_behavior=TestBehavior.AFTER_EACH,
+    dbt_executable_path=DBT_EXECUTABLE,
+    # DAG 파싱 시점의 dbt ls도 같은 이유로 별도 프로세스에서 돌린다.
+    invocation_mode=InvocationMode.SUBPROCESS,
+)
+
+# GA4는 확정 데이터를 최근 며칠에 걸쳐 갱신하므로 매 실행 3일치를 다시 만든다.
+# insert_overwrite라 파티션이 통째로 교체되어 삭제·변경까지 반영된다.
+LOOKBACK_DAYS = 3
+
+# 처리 날짜는 항상 Airflow가 정한다.
+#   * 스케줄 실행: 담당 구간(data_interval_start) 기준 최근 LOOKBACK_DAYS일
+#   * 수동 실행  : Trigger DAG w/ config로 넘긴 날짜를 그대로 사용
+#       {"start_date": "20240711", "end_date": "20260725"}   ← 전체 적재도 이렇게
+# dag_run.conf가 없는 스케줄 실행에서도 안전하도록 conf 자체를 or로 감싼다.
+CONF = "(dag_run.conf or {})"
+DATE_VARS = {
+    "start_date": (
+        "{{ %s.get('start_date')"
+        " or (data_interval_start - macros.timedelta(days=%d)) | ds_nodash }}"
+        % (CONF, LOOKBACK_DAYS)
+    ),
+    "end_date": "{{ %s.get('end_date') or data_interval_start | ds_nodash }}" % CONF,
+}
+
+dbt_ga4_daily = DbtDag(
+    dag_id="dbt_ga4_daily",
+    project_config=project_config,
+    profile_config=profile_config,
+    execution_config=execution_config,
+    render_config=render_config,
+    operator_args={"vars": DATE_VARS},
+    # 전날 데이터를 KST 오전에 처리한다. GA4 확정 export가 도착할 시간을 준다.
+    schedule="0 9 * * *",
+    start_date=pendulum.datetime(2026, 7, 25, tz="Asia/Seoul"),
+    catchup=False,
+    default_args={
+        "retries": 1,
+        "retry_delay": timedelta(minutes=5),
+    },
+    tags=["dbt", "ga4", "silver"],
+    doc_md=__doc__,
+)

--- a/dbt/models/silver/silver_events.sql
+++ b/dbt/models/silver/silver_events.sql
@@ -35,8 +35,21 @@
     {{ exceptions.raise_compiler_error('start_date와 end_date는 반드시 함께 지정해야 합니다.') }}
 {% endif %}
 
-{% if start_date and end_date and (start_date | length != 8 or end_date | length != 8 or start_date > end_date) %}
-    {{ exceptions.raise_compiler_error('start_date와 end_date는 YYYYMMDD 형식이며 시작일이 종료일보다 늦을 수 없습니다.') }}
+{#-
+  두 값은 SQL 리터럴로 직접 삽입되므로 숫자 8자리만 허용한다.
+  길이만 검사하면 `1' or '1` 처럼 8자짜리 문자열이 통과해 SQL을 벗어난다.
+-#}
+{% if start_date and end_date %}
+    {% for value in [start_date, end_date] %}
+        {% if not modules.re.match('^\d{8}$', value) %}
+            {{ exceptions.raise_compiler_error(
+                "start_date와 end_date는 숫자 8자리(YYYYMMDD)여야 합니다. 받은 값: '" ~ value ~ "'"
+            ) }}
+        {% endif %}
+    {% endfor %}
+    {% if start_date > end_date %}
+        {{ exceptions.raise_compiler_error('start_date가 end_date보다 늦을 수 없습니다.') }}
+    {% endif %}
 {% endif %}
 
 {#-

--- a/dbt/models/silver/silver_events.sql
+++ b/dbt/models/silver/silver_events.sql
@@ -12,6 +12,20 @@
     )
 }}
 
+{#-
+  처리 범위는 호출자(Airflow 또는 사람)가 정한다.
+
+    * 기본     : vars 없이 실행하면 최근 3일(어제 기준)을 다시 계산해 교체
+    * 범위 지정: dbt run --vars '{"start_date":"YYYYMMDD","end_date":"YYYYMMDD"}'
+    * 전체 적재: 분석 시작일을 명시한다
+                 --vars '{"start_date":"20240711","end_date":"YYYYMMDD"}'
+
+  전체 적재는 2년치를 스캔하므로 실수로 발생하지 않도록 항상 명시를 요구한다.
+-#}
+{% set ANALYSIS_START_DATE = '20240711' %}
+{% set LOOKBACK_DAYS = 3 %}
+{% set SIGNUP_LOOKBACK_MINUTES = 15 %}
+
 {% set start_date_var = var('start_date', none) %}
 {% set end_date_var = var('end_date', none) %}
 {% set start_date = start_date_var | string if start_date_var is not none else none %}
@@ -25,27 +39,43 @@
     {{ exceptions.raise_compiler_error('start_date와 end_date는 YYYYMMDD 형식이며 시작일이 종료일보다 늦을 수 없습니다.') }}
 {% endif %}
 
--- 처리 기준
---   * 전체 적재: 합의된 분석 시작일인 2024-07-11부터 어제까지
---   * 범위 백필: start_date/end_date(YYYYMMDD)로 지정한 파티션만 계산해 교체
---   * 증분 적재: 완료된 최근 3일 파티션을 다시 계산해 원자적으로 교체
---   * Android 가입 세션: 최초 시작일을 제외한 범위는 15분 앞선 이벤트까지 읽는다.
+{#-
+  교체할 파티션 범위. vars가 없으면 최근 LOOKBACK_DAYS일.
+-#}
+{% if start_date and end_date %}
+    {% set target_start_sql = "parse_date('%Y%m%d', '" ~ start_date ~ "')" %}
+    {% set target_end_sql = "parse_date('%Y%m%d', '" ~ end_date ~ "')" %}
+{% else %}
+    {% set target_start_sql = "date_sub(current_date('Asia/Seoul'), interval " ~ LOOKBACK_DAYS ~ " day)" %}
+    {% set target_end_sql = "date_sub(current_date('Asia/Seoul'), interval 1 day)" %}
+{% endif %}
+
+{#-
+  Android 가입 세션은 시작 시각보다 앞선 이벤트를 상속해야 하므로 범위 앞쪽을
+  SIGNUP_LOOKBACK_MINUTES만큼 더 읽는다. 그 lookback이 자정을 넘어 전날 테이블로
+  넘어갈 수 있어 스캔 범위도 하루 더 넓힌다.
+  분석 시작일에는 앞선 데이터 자체가 없으므로 둘 다 적용하지 않는다.
+-#}
+{% set apply_signup_lookback = start_date != ANALYSIS_START_DATE %}
+
+{% if apply_signup_lookback %}
+    {% set scan_start_sql = "format_date('%Y%m%d', date_sub(" ~ target_start_sql ~ ", interval 1 day))" %}
+{% else %}
+    {% set scan_start_sql = "'" ~ ANALYSIS_START_DATE ~ "'" %}
+{% endif %}
+
+{#- 날짜를 명시받았으면 리터럴로 둔다. BigQuery가 스캔할 테이블을 더 확실히 줄인다. -#}
+{% if end_date %}
+    {% set scan_end_sql = "'" ~ end_date ~ "'" %}
+{% else %}
+    {% set scan_end_sql = "format_date('%Y%m%d', " ~ target_end_sql ~ ")" %}
+{% endif %}
 
 with date_window as (
 
     select
-        {% if start_date and end_date %}
-            parse_date('%Y%m%d', '{{ start_date }}') as target_start_dt,
-        {% elif is_incremental() %}
-            date_sub(current_date('Asia/Seoul'), interval 3 day) as target_start_dt,
-        {% else %}
-            date '2024-07-11' as target_start_dt,
-        {% endif %}
-        {% if start_date and end_date %}
-            parse_date('%Y%m%d', '{{ end_date }}') as target_end_dt
-        {% else %}
-            date_sub(current_date('Asia/Seoul'), interval 1 day) as target_end_dt
-        {% endif %}
+        {{ target_start_sql }} as target_start_dt,
+        {{ target_end_sql }} as target_end_dt
 
 ),
 
@@ -54,14 +84,14 @@ input_window as (
     select
         target_start_dt,
         target_end_dt,
-        if(
-            target_start_dt = date '2024-07-11',
+        {% if apply_signup_lookback %}
+        datetime_sub(
             datetime(target_start_dt, time '00:00:00'),
-            datetime_sub(
-                datetime(target_start_dt, time '00:00:00'),
-                interval 15 minute
-            )
+            interval {{ SIGNUP_LOOKBACK_MINUTES }} minute
         ) as input_start_at,
+        {% else %}
+        datetime(target_start_dt, time '00:00:00') as input_start_at,
+        {% endif %}
         datetime(
             date_add(target_end_dt, interval 1 day),
             time '00:00:00'
@@ -78,28 +108,10 @@ source_filtered as (
         _table_suffix as source_table_suffix
     from {{ source('ga4', 'events') }} as e
     cross join input_window as input_range
+    -- _table_suffix 조건은 BigQuery가 스캔할 테이블을 미리 줄이도록
+    -- CTE 값이 아닌 상수 식으로 직접 쓴다.
     where regexp_contains(_table_suffix, r'^\d{8}$')
-      {% if start_date and end_date %}
-      and _table_suffix between
-          {% if start_date == '20240711' %}
-          '{{ start_date }}'
-          {% else %}
-          format_date(
-              '%Y%m%d',
-              date_sub(parse_date('%Y%m%d', '{{ start_date }}'), interval 1 day)
-          )
-          {% endif %}
-          and '{{ end_date }}'
-      {% elif is_incremental() %}
-      -- target_start_dt의 15분 lookback이 전날로 넘어갈 수 있어 하루를 더 스캔한다.
-      and _table_suffix between
-          format_date('%Y%m%d', date_sub(current_date('Asia/Seoul'), interval 4 day))
-          and format_date('%Y%m%d', date_sub(current_date('Asia/Seoul'), interval 1 day))
-      {% else %}
-      and _table_suffix between
-          '20240711'
-          and format_date('%Y%m%d', date_sub(current_date('Asia/Seoul'), interval 1 day))
-      {% endif %}
+      and _table_suffix between {{ scan_start_sql }} and {{ scan_end_sql }}
       and datetime(timestamp_micros(e.event_timestamp), 'Asia/Seoul') >= input_range.input_start_at
       and datetime(timestamp_micros(e.event_timestamp), 'Asia/Seoul') < input_range.input_end_at
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,10 @@ x-airflow-common: &airflow-common
     - ./airflow/dags:/opt/airflow/dags
     - ./airflow/plugins:/opt/airflow/plugins
     - ./airflow/logs:/opt/airflow/logs
-    - ./secrets:/opt/airflow/secrets:ro
+    # dbt 컨테이너와 같은 경로를 쓴다. profiles.yml의 prod keyfile 기본값이
+    # /secrets/gcp-service-account.json 이므로, 경로를 통일해두면 서버에서
+    # GOOGLE_APPLICATION_CREDENTIALS를 따로 설정하지 않아도 맞는다.
+    - ./secrets:/secrets:ro
     - ./airflow/passwords.json:/opt/airflow/simple_auth_manager_passwords.json.generated
     # dbt 프로젝트(네 SQL 모델들)를 실시간 연결 — Cosmos가 이걸 읽어 task로 변환.
     # target/ logs/ 를 dbt가 써야 하므로 read-only(:ro) 아님.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,13 @@ x-airflow-common: &airflow-common
     AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://${KOIN_DATA_POSTGRES_USER:-koin}:${KOIN_DATA_POSTGRES_PASSWORD:-change_me}@postgres:5432/${KOIN_DATA_AIRFLOW_DB:-airflow_metadata}
     # 프록시(Caddy) 뒤 공개 주소. 로컬은 localhost, 서버는 .env에서 https://airflow.bcsdlab.com 로 override
     AIRFLOW__API__BASE_URL: ${KOIN_DATA_AIRFLOW_BASE_URL:-http://localhost:8080}
+    # Airflow 3의 task는 실행 전 Execution API로 실행 정보를 받아온다.
+    # scheduler와 api-server가 다른 컨테이너이므로 도커 네트워크 주소로 지정해야 한다.
+    # (기본값 localhost:8080은 scheduler 자신을 가리켜 Connection refused)
+    AIRFLOW__CORE__EXECUTION_API_SERVER_URL: http://airflow-webserver:8080/execution/
+    # Execution API는 JWT로 보호된다. 지정하지 않으면 컨테이너마다 랜덤 키를 만들어
+    # scheduler가 서명한 토큰을 api-server가 거부한다(403). 두 컨테이너가 같은 값을 써야 한다.
+    AIRFLOW__API_AUTH__JWT_SECRET: ${KOIN_DATA_AIRFLOW_JWT_SECRET:-change_me_jwt_secret}
   volumes:
     - ./airflow/dags:/opt/airflow/dags
     - ./airflow/plugins:/opt/airflow/plugins

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,9 @@ x-airflow-common: &airflow-common
     AIRFLOW__CORE__EXECUTION_API_SERVER_URL: http://airflow-webserver:8080/execution/
     # Execution API는 JWT로 보호된다. 지정하지 않으면 컨테이너마다 랜덤 키를 만들어
     # scheduler가 서명한 토큰을 api-server가 거부한다(403). 두 컨테이너가 같은 값을 써야 한다.
-    AIRFLOW__API_AUTH__JWT_SECRET: ${KOIN_DATA_AIRFLOW_JWT_SECRET:-change_me_jwt_secret}
+    # 기본값을 두지 않는다. 값이 없으면 컨테이너가 뜨지 않아 설정 누락을 바로 알 수 있다.
+    # (기본값이 있으면 서버에서 깜빡했을 때 예측 가능한 키로 조용히 운영된다)
+    AIRFLOW__API_AUTH__JWT_SECRET: "${KOIN_DATA_AIRFLOW_JWT_SECRET:?.env에 KOIN_DATA_AIRFLOW_JWT_SECRET을 설정하세요. openssl rand -base64 32 으로 생성하세요}"
   volumes:
     - ./airflow/dags:/opt/airflow/dags
     - ./airflow/plugins:/opt/airflow/plugins

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,12 @@ x-airflow-common: &airflow-common
     - ./airflow/logs:/opt/airflow/logs
     - ./secrets:/opt/airflow/secrets:ro
     - ./airflow/passwords.json:/opt/airflow/simple_auth_manager_passwords.json.generated
+    # dbt 프로젝트(네 SQL 모델들)를 실시간 연결 — Cosmos가 이걸 읽어 task로 변환.
+    # target/ logs/ 를 dbt가 써야 하므로 read-only(:ro) 아님.
+    - ./dbt:/opt/airflow/dbt
+    # 로컬 dev(oauth) 인증 — 네가 gcloud로 로그인해둔 ADC를 airflow 방에 빌려줌.
+    # 서버(prod)는 secrets의 서비스계정 키를 쓰므로 이 줄과 무관.
+    - ${HOME}/.config/gcloud:/home/airflow/.config/gcloud:ro
   depends_on:
     postgres:
       condition: service_healthy

--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -4,3 +4,10 @@ COPY docker/airflow/requirements.txt /requirements.txt
 RUN pip install --no-cache-dir \
     --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.0.1/constraints-3.11.txt" \
     -r /requirements.txt
+
+# dbt 전용 격리 venv(옆방)를 이미지에 미리 구워둠.
+# Airflow 본체와 파이썬 라이브러리가 섞이지 않게 분리 + 런타임 설치 없이 재현성 확보.
+# airflow 사용자 소유 경로(/home/airflow)에 둬야 권한 문제가 없다.
+# Cosmos가 이 venv의 dbt(/home/airflow/dbt-venv/bin/dbt)를 실행하도록 DAG에서 지정한다.
+RUN python -m venv /home/airflow/dbt-venv && \
+    /home/airflow/dbt-venv/bin/pip install --no-cache-dir dbt-bigquery~=1.9.0

--- a/docker/airflow/requirements.txt
+++ b/docker/airflow/requirements.txt
@@ -1,1 +1,2 @@
 apache-airflow-providers-google
+astronomer-cosmos

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,30 +4,52 @@
 
 ```text
 GA4
-  -> Google Analytics BigQuery Export
-  -> BigQuery raw_ga4
-  -> Airflow/dbt on Docker Compose
-  -> BigQuery bronze/silver/gold
+  -> Google Analytics BigQuery Export (Bronze, 손대지 않음)
+  -> Airflow(Cosmos) + dbt on Docker Compose
+  -> BigQuery silver/gold
   -> Superset dashboards
 ```
 
 ## 실행 환경
 
-- 우선 실행 환경은 GCP Compute Engine의 Ubuntu Server VM을 기준으로 합니다.
+- 실행 환경은 AWS Lightsail의 Ubuntu Server를 기준으로 합니다.
 - 서버에는 Docker Engine과 Docker Compose plugin만 설치합니다.
-- VM은 서비스 실행과 관리를 담당합니다.
+- 서버는 서비스 실행과 관리를 담당합니다.
 - 대량 데이터 저장과 처리는 BigQuery가 담당합니다.
-- Compute Engine에서는 service account를 붙여 BigQuery에 접근하는 방식을 우선 고려합니다.
-- 가능하면 service account JSON key 파일을 서버에 두지 않습니다.
+- BigQuery 접근은 환경에 따라 나눕니다.
+  - 로컬(dev): 개발자 OAuth(gcloud ADC)로 stage 프로젝트에 접근
+  - 서버(prod): 전용 service account 키로 운영 프로젝트에 접근
+- service account 키는 `secrets/`에만 두고 Git에 올리지 않습니다.
 
 ## dbt 레이어
 
-- `sources`: GA4 export 원본 테이블 선언
-- `staging`: 컬럼명 정리와 타입 캐스팅
-- `bronze`: 프로젝트가 관리하는 canonical schema
-- `silver`: 분석용 entity 테이블
-- `marts`: Superset이 조회하는 gold 테이블
+Medallion 3층 구조를 쓰되, Bronze는 GA4 Export를 그대로 사용하므로 직접 만들지 않습니다.
+
+| 레이어 | 내용 | materialization |
+| --- | --- | --- |
+| `sources` | GA4 export 원본 테이블 선언 | - |
+| `silver` | 정제 + 비즈니스 로직을 적용한 분석용 테이블 | 기본 view, 대용량은 incremental |
+| `gold` | KPI/집계, 대시보드가 직접 조회 | table |
+
+dbt 공식 권장 이름(`staging`/`intermediate`/`marts`) 대신 조직 용어에 맞춰
+`silver`/`gold`를 폴더명과 데이터셋명에 함께 사용합니다.
+
+## 환경 분리
+
+| 환경 | 입력(GA4) | 출력 |
+| --- | --- | --- |
+| dev | stage 프로젝트 | stage 프로젝트 |
+| prod | 운영 프로젝트 | 운영 프로젝트 |
+
+입력은 `_ga4__sources.yml`(`KOIN_DATA_GA4_*`), 출력은 `profiles.yml`(`DBT_TARGET`,
+`KOIN_DATA_GCP_PROJECT`)이 결정합니다. 둘 다 기본값은 stage이며, 운영은 환경변수로
+명시할 때만 사용합니다.
+
+## 오케스트레이션
+
+Airflow가 dbt를 실행하며, dbt 모델은 Cosmos가 모델 단위 task로 변환합니다.
+자세한 내용은 [airflow/README.md](../airflow/README.md)를 참고합니다.
 
 ## Superset
 
-Superset은 BigQuery 비용과 대시보드 안정성을 위해 `marts`/gold 테이블만 조회하도록 구성합니다.
+Superset은 BigQuery 비용과 대시보드 안정성을 위해 gold 테이블만 조회하도록 구성합니다.


### PR DESCRIPTION
Airflow에서 dbt를 실행하는 첫 파이프라인입니다. 로컬에서 UI 실행까지 검증했습니다.

## 구성

```
[validate_dates] → [silver_events.run] → [silver_events.test]
```

Cosmos가 dbt 프로젝트를 읽어 모델 단위 task를 만들고, `ref()` 의존성이 task 순서가 됩니다.

**"도구는 굽고, 코드는 마운트"**

| 위치 | 내용 | 반영 |
| --- | --- | --- |
| `/home/airflow/dbt-venv` | dbt 실행 파일 (격리 venv) | 이미지 빌드 |
| `/opt/airflow/dbt` | dbt 프로젝트 (`./dbt` 마운트) | 파일 수정 즉시 |
| `/opt/airflow/dags` | DAG (`./airflow/dags` 마운트) | 파일 수정 즉시 |

dbt는 Airflow 본체와 라이브러리를 공유하지 않도록 별도 venv에 설치해 이미지에 굽습니다.
런타임 설치가 없어 빠르고 재현 가능합니다. Cosmos는 `InvocationMode.SUBPROCESS`로 이 venv의 dbt를 호출합니다.

## 날짜 처리

처리 날짜는 **항상 Airflow가 결정**하고 dbt에 `--vars`로 넘깁니다.

| 실행 | 범위 |
| --- | --- |
| 스케줄 (매일 09:00 KST) | 어제까지의 최근 3일 |
| 수동 (Trigger DAG w/ config) | conf의 `start_date` ~ `end_date` |

전체 적재(2년치)도 수동 트리거로 날짜를 명시합니다. 자동 분기를 두지 않아 큰 스캔이 실수로 발생하지 않습니다.

```json
{"start_date": "20240711", "end_date": "20260725"}
```

## silver_events 리팩터링

날짜 분기가 두 곳에 3갈래씩 흩어지고 분석 시작일이 4곳에 하드코딩돼 있어 정리했습니다.

- 매직 상수 추출, 분기를 Jinja에서 한 번만 계산 (6곳 → 1곳)
- 스캔 범위를 하루 더 넓히는 이유(15분 가입 세션 lookback)를 코드로 연결
- `is_incremental()` 분기 제거 — 테이블 존재 여부로 처리 범위가 달라지지 않습니다

**동작 변경**: 기존에는 테이블이 없으면 vars 없이도 2024-07-11부터 전체를 적재했습니다.
이제 vars 없이 실행하면 항상 최근 3일만 처리하고, 전체 적재는 날짜를 명시해야 합니다.

리팩터링 전/후를 각 모드로 컴파일해 SQL을 diff로 대조했고, `_table_suffix` 조건은 리터럴까지 동일합니다.

## Airflow 3 설정 (task 실행 불가 해소)

DAG 파싱과 dbt CLI 직접 실행은 됐지만 Airflow를 통한 task 실행이 실패했습니다.
Airflow 3의 task는 실행 전 Execution API에서 실행 정보를 받아오는데 그 경로가 막혀 있었습니다.

| 증상 | 원인 | 해결 |
| --- | --- | --- |
| `Connection refused` | 기본값 `localhost:8080`이 scheduler 자신을 가리킴 | `AIRFLOW__CORE__EXECUTION_API_SERVER_URL` |
| `403 Forbidden` | JWT 키를 지정하지 않아 컨테이너마다 랜덤 생성 | `AIRFLOW__API_AUTH__JWT_SECRET` 공유 |

`.env`의 `AIRFLOW__WEBSERVER__SECRET_KEY`는 Airflow 2용이라 무관합니다.

## 보안

- **SQL 삽입 차단**: 날짜 vars는 모델에서 SQL 리터럴로 삽입되는데 검증이 길이만 봐서
  `1' or '1` 같은 8자 문자열이 리터럴을 벗어날 수 있었습니다.
  정규식으로 숫자 8자리만 허용하도록 모델과 DAG 양쪽에 넣었습니다.
  (모델 쪽은 CLI 직접 실행도 막는 최종 방어선)
- **JWT secret 필수화**: 기본값이 있으면 서버에서 깜빡했을 때 예측 가능한 키로 조용히 운영됩니다.
  `${VAR:?...}`로 바꿔 누락 시 컨테이너가 뜨지 않게 했습니다.
- **secrets 경로 통일**: airflow만 `/opt/airflow/secrets`였습니다. 모든 컨테이너 `/secrets`로 맞춰
  `profiles.yml`의 prod keyfile 기본값이 그대로 동작합니다.

## 문서

- `airflow/README.md`: 레거시 repo 구조(`dags/koin/`, `query/`, `sensors/`) 설명을 실제 구조로 교체.
  DAG/task 네이밍 컨벤션, dbt 실행 구조, 날짜 처리 규칙 추가
- `docs/architecture.md`: 4층 레이어 → Medallion(silver/gold), GCE VM → Lightsail, 환경 분리 설명

## 검증

- 로컬 UI에서 스케줄 실행 → `silver_events.run`(PASS=1) → `silver_events.test`(PASS=10)
- 수동 트리거로 7일치 범위 지정 실행 → 해당 파티션 적재 확인
- 리팩터링 전/후 컴파일 SQL diff 대조
- 날짜 검증: 주입 시도 / 문자 포함 / 7자리 / 반쪽만 / 역순 모두 차단
- JWT 누락 시 `docker compose config` 실패, 있을 때 정상 기동

## 배포 전 필요한 것

- [ ] 서버 `.env`에 `KOIN_DATA_AIRFLOW_JWT_SECRET` 생성 (`openssl rand -base64 32`) — 없으면 컨테이너가 뜨지 않습니다
- [ ] `docker compose build` (이미지에 cosmos + dbt venv가 새로 들어감)
- [ ] prod에는 `silver_events`가 없어 첫 실행은 수동 트리거로 범위를 지정해야 합니다
- [ ] prod 잔재 정리: `kap-chat.silver.silver_events_temp`, `silver_ga4_events`(VIEW)

## 별건 (이 PR 범위 밖)

Airflow가 공개된 상태에서 비밀번호가 `admin1234`입니다. Superset도 `admin`/`admin`입니다.
로그인만 되면 DAG 트리거와 Connection 조회가 가능하니 별도로 강화가 필요합니다.

Cosmos 1.15의 AF3 플러그인은 Airflow >= 3.1을 요구해 `Failed to import plugin cosmos` 경고가 남습니다.
dbt docs 링크를 UI에 노출하는 부가 기능이라 DAG 실행에는 영향이 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a daily GA4-to-BigQuery pipeline with automated dbt model execution and testing.
  * Added support for scheduled three-day refreshes and validated manual date-range runs.
  * Improved date-window handling for event and signup data.

* **Configuration**
  * Added required Airflow JWT secret configuration.
  * Updated credential guidance for local OAuth and service-account access.

* **Documentation**
  * Updated Airflow setup, pipeline execution, date handling, access instructions, and system architecture documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->