### PR TITLE
feat: add production silver v2 models

### DIFF
--- a/dbt/models/silver/_app_db__sources.yml
+++ b/dbt/models/silver/_app_db__sources.yml
@@ -1,0 +1,13 @@
+version: 2
+
+sources:
+  - name: app_db
+    description: >
+      운영 앱 회원 테이블의 논리적 dbt source다. 현재 물리 테이블은
+      kap-chat.analytics_432041405.koin_users에 있으며, 배포 환경에서는
+      KOIN_DATA_APP_DB_PROJECT와 KOIN_DATA_APP_DB_DATASET으로 명시한다.
+    database: "{{ env_var('KOIN_DATA_APP_DB_PROJECT', 'kap-chat') }}"
+    schema: "{{ env_var('KOIN_DATA_APP_DB_DATASET', 'analytics_432041405') }}"
+    tables:
+      - name: koin_users
+        description: KOIN 앱 회원 정보 스냅샷

--- a/dbt/models/silver/_ga4__sources.yml
+++ b/dbt/models/silver/_ga4__sources.yml
@@ -3,13 +3,11 @@ version: 2
 sources:
   - name: ga4
     description: >
-      GA4 BigQuery Export — 메인 사이트(koreatech.in) 이벤트 스트림.
-      기본 원본은 stage(koin-stage-438512.analytics_427218788)이며,
-      운영(kap-chat.analytics_432041405)은 환경변수로 명시할 때만 읽는다.
-      환경변수를 깜빡해도 운영 데이터를 읽지 않도록 기본값을 stage로 둔다.
+      GA4 BigQuery Export — 메인 사이트(koreatech.in) production 이벤트 스트림.
+      기본 원본은 kap-chat.analytics_432041405이며, 다른 환경은 환경변수로 재정의한다.
       데이터셋 이름은 GA4가 자동 관리하므로 여기서 별명(ga4)으로 가린다.
-    database: "{{ env_var('KOIN_DATA_GA4_PROJECT', 'koin-stage-438512') }}"
-    schema: "{{ env_var('KOIN_DATA_GA4_DATASET', 'analytics_427218788') }}"
+    database: "{{ env_var('KOIN_DATA_GA4_PROJECT', 'kap-chat') }}"
+    schema: "{{ env_var('KOIN_DATA_GA4_DATASET', 'analytics_432041405') }}"
     tables:
       - name: events
         description: >

--- a/dbt/models/silver/_silver__users.yml
+++ b/dbt/models/silver/_silver__users.yml
@@ -1,0 +1,31 @@
+version: 2
+
+models:
+  - name: silver__users
+    description: >
+      Prod GA4 원천과 KOIN 회원 정보를 결합하는 운영 전환 후보 사용자
+      Dimension이다. 로컬 Airflow 검증에서는 Stage silver 데이터셋에만 적재한다.
+    columns:
+      - name: user_pseudo_id
+        description: GA4 사용자 인스턴스 식별자이자 모델의 논리 PK
+        data_tests:
+          - not_null
+          - unique
+      - name: first_seen_at
+        description: 사용자 상태 산정에 포함된 첫 관측 시각(KST)
+        data_tests:
+          - not_null
+      - name: last_seen_at
+        description: 사용자 상태 산정에 포함된 마지막 관측 시각(KST)
+        data_tests:
+          - not_null
+      - name: user_type
+        description: koin_users의 회원 유형
+      - name: signup_completed_at
+        description: koin_users.created_at 기반 회원가입 완료 시각
+      - name: is_deleted
+        description: koin_users.is_deleted의 정수화 값
+      - name: is_mysql_mapped
+        description: 선정된 user_id가 koin_users에 매핑됐는지 여부
+        data_tests:
+          - not_null

--- a/dbt/models/silver/_silver_events_v2.yml
+++ b/dbt/models/silver/_silver_events_v2.yml
@@ -1,0 +1,88 @@
+version: 2
+
+models:
+  - name: silver_events_v2
+    description: >
+      GA4 확정 일별 Export를 이벤트 grain으로 정제한 Silver 증분 테이블.
+      raw_event_id 물리 중복 제거와 event_id 논리 중복 제거를 UNNEST 전에 수행하고,
+      공통 이벤트 파라미터·KST 시간·화면명·Android 가입 세션을 표준화한다.
+    columns:
+      - name: event_id
+        description: 사용자·시각·이벤트 내용으로 생성하고 논리 중복을 제거한 Silver PK
+        data_tests:
+          - not_null
+          - unique
+
+      - name: event_dt
+        description: Asia/Seoul 기준 이벤트 날짜이자 테이블 파티션 키
+        data_tests:
+          - not_null
+
+      - name: event_at
+        description: Asia/Seoul 기준 이벤트 현지 일시(DATETIME)
+        data_tests:
+          - not_null
+
+      - name: event_ts
+        description: GA4 event_timestamp 원본 마이크로초 값(INT64)
+        data_tests:
+          - not_null
+
+      - name: event_name
+        description: GA4 이벤트 이름
+        data_tests:
+          - not_null
+
+      - name: user_pseudo_id
+        description: GA4 가명 사용자 식별자. 동의 거부로 발생하는 정상 NULL을 허용한다.
+
+      - name: ga_session_id
+        description: event_params에서 추출한 GA4 세션 식별자
+
+      - name: custom_session_id
+        description: 원본 값을 우선하고 Android 회원가입 이벤트는 15분 규칙으로 보정한 세션 식별자
+
+      - name: platform
+        description: 이벤트 발생 플랫폼(WEB, ANDROID, IOS 등)
+        data_tests:
+          - not_null
+
+      - name: device_category
+        description: GA4 device.category
+        data_tests:
+          - not_null
+
+      - name: device_os
+        description: GA4 device.operating_system. 정상 NULL을 허용하며 별도로 모니터링한다.
+
+      - name: device_os_version
+        description: GA4 device.operating_system_version
+
+      - name: event_label
+        description: event_params의 event_label
+
+      - name: event_category
+        description: event_params의 event_category
+
+      - name: event_value
+        description: event_params의 value를 STRING으로 표준화한 값
+
+      - name: page_title
+        description: event_params의 page_title
+
+      - name: screen_class
+        description: screen_name 우선순위와 Activity 이름 보정을 적용한 화면 클래스
+
+      - name: engagement_time_msec
+        description: event_params의 engagement_time_msec를 INT64로 안전 변환한 값
+
+      - name: page_location
+        description: event_params의 page_location URL
+      - name: service_name
+        description: 정규화된 이벤트 속성으로 분류한 KOIN 서비스명입니다.
+        data_tests:
+          - not_null
+      - name: stage_scope
+        description: main 이벤트는 global, 그 외 서비스 이벤트는 service입니다.
+        data_tests:
+          - not_null

--- a/dbt/models/silver/silver__users.sql
+++ b/dbt/models/silver/silver__users.sql
@@ -1,0 +1,716 @@
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key='user_pseudo_id',
+        cluster_by=['user_pseudo_id', 'user_id'],
+        on_schema_change='fail'
+    )
+}}
+
+{#-
+  운영 전환 후보 사용자 Dimension.
+  날짜 처리는 Lightsail 운영 silver_events와 같은 원본 흐름을 따른다.
+
+    * 기본     : vars 없이 실행하면 최근 3일(어제 기준)의 관측값을 MERGE한다.
+    * 범위 지정: dbt run --vars '{"start_date":"YYYYMMDD","end_date":"YYYYMMDD"}'
+    * 최초 운영: 전체 GA4 이력을 명시 범위로 수동 실행해 Dimension을 만든다.
+
+  개선 후보 (현재 동작을 유지하기 위해 적용하지 않음):
+
+    * Airflow 실행은 항상 start_date/end_date를 넘겨 재시도·백필 범위를 고정한다.
+    * user Dimension의 최초 Prod 적재는 최근 3일 기본값을 쓰면 불완전해진다.
+      아래 보호막을 유지하고, 전체 이력을 명시한 수동 실행 뒤에만 일일 스케줄을 켠다.
+    * user는 날짜 fact가 아니므로 events처럼 insert_overwrite 파티션 모델로 바꾸지 않고
+      user_pseudo_id 기준 MERGE를 유지한다.
+-#}
+{% set LOOKBACK_DAYS = 3 %}
+
+{% set start_date_var = var('start_date', none) %}
+{% set end_date_var = var('end_date', none) %}
+{% set start_date = start_date_var | string if start_date_var is not none else none %}
+{% set end_date = end_date_var | string if end_date_var is not none else none %}
+{# compile 시 존재하지 않는 대상 테이블을 참조하지 않도록 하는 전용 변수 #}
+{% set incremental_mode = is_incremental() or var('_compile_incremental', false) %}
+
+{#- SQL 리터럴에 직접 쓰는 날짜는 숫자 8자리만 허용한다. -#}
+{% if (start_date and not end_date) or (end_date and not start_date) %}
+    {{ exceptions.raise_compiler_error('start_date와 end_date는 반드시 함께 지정해야 합니다.') }}
+{% endif %}
+
+{% if start_date and end_date %}
+    {% for value in [start_date, end_date] %}
+        {% if not modules.re.match('^[0-9]{8}$', value) %}
+            {{ exceptions.raise_compiler_error(
+                "start_date와 end_date는 숫자 8자리(YYYYMMDD)여야 합니다. 받은 값: '" ~ value ~ "'"
+            ) }}
+        {% endif %}
+    {% endfor %}
+    {% if start_date > end_date %}
+        {{ exceptions.raise_compiler_error('start_date가 end_date보다 늦을 수 없습니다.') }}
+    {% endif %}
+{% endif %}
+
+{#- Prod 최초 실행이 최근 3일 기본값으로 불완전하게 생성되는 것을 막는다. -#}
+{% if execute and target.name == 'prod' and not is_incremental() %}
+    {% if not start_date or not end_date %}
+        {{ exceptions.raise_compiler_error(
+            'silver__users 최초 운영 실행은 전체 GA4 이력의 '
+            ~ 'start_date/end_date를 지정해 수동 실행해야 합니다.'
+        ) }}
+    {% else %}
+        {% set initial_range_days = (
+            modules.datetime.datetime.strptime(end_date, '%Y%m%d')
+            - modules.datetime.datetime.strptime(start_date, '%Y%m%d')
+        ).days + 1 %}
+        {% if initial_range_days <= LOOKBACK_DAYS %}
+            {{ exceptions.raise_compiler_error(
+                'silver__users 최초 운영 실행은 3일 스케줄이 아니라 '
+                ~ '전체 GA4 이력의 start_date/end_date로 수동 실행해야 합니다.'
+            ) }}
+        {% endif %}
+    {% endif %}
+{% endif %}
+
+{% if start_date and end_date %}
+    {% set target_start_sql = "parse_date('%Y%m%d', '" ~ start_date ~ "')" %}
+    {% set target_end_sql = "parse_date('%Y%m%d', '" ~ end_date ~ "')" %}
+{% else %}
+    {% set target_start_sql = "date_sub(current_date('Asia/Seoul'), interval " ~ LOOKBACK_DAYS ~ " day)" %}
+    {% set target_end_sql = "date_sub(current_date('Asia/Seoul'), interval 1 day)" %}
+{% endif %}
+
+{# KST 하루의 앞부분이 전날 UTC suffix에 있을 수 있어 하루 앞 테이블부터 읽는다. #}
+{% set scan_start_sql = "format_date('%Y%m%d', date_sub(" ~ target_start_sql ~ ", interval 1 day))" %}
+{% if end_date %}
+    {% set scan_end_sql = "'" ~ end_date ~ "'" %}
+{% else %}
+    {% set scan_end_sql = "format_date('%Y%m%d', " ~ target_end_sql ~ ")" %}
+{% endif %}
+
+with existing_users as (
+
+    {% if incremental_mode %}
+    select
+        user_pseudo_id,
+        stream_id,
+        user_id,
+        user_id_source,
+        top_user_id,
+        property_user_id,
+        param_user_id,
+        gender,
+        major,
+        entry_year,
+        first_seen_at,
+        last_seen_at,
+        user_id_support_count,
+        source_event_count,
+        property_user_id_set_ts
+    from {{ this }}
+    {% else %}
+    select
+        cast(null as string) as user_pseudo_id,
+        cast(null as string) as stream_id,
+        cast(null as string) as user_id,
+        cast(null as string) as user_id_source,
+        cast(null as string) as top_user_id,
+        cast(null as string) as property_user_id,
+        cast(null as string) as param_user_id,
+        cast(null as string) as gender,
+        cast(null as string) as major,
+        cast(null as int64) as entry_year,
+        cast(null as datetime) as first_seen_at,
+        cast(null as datetime) as last_seen_at,
+        cast(null as int64) as user_id_support_count,
+        cast(null as int64) as source_event_count,
+        cast(null as int64) as property_user_id_set_ts
+    from (select 1) as empty_source
+    where false
+    {% endif %}
+
+),
+
+source_filtered as (
+
+    select
+        e.stream_id,
+        e.event_timestamp as event_ts,
+        datetime(
+            timestamp_micros(e.event_timestamp),
+            'Asia/Seoul'
+        ) as event_at,
+        date(
+            timestamp_micros(e.event_timestamp),
+            'Asia/Seoul'
+        ) as event_dt,
+        e.user_pseudo_id,
+        e.user_id as top_user_id_raw,
+        (
+            select as struct
+                coalesce(
+                    property.value.string_value,
+                    cast(property.value.int_value as string),
+                    cast(property.value.float_value as string),
+                    cast(property.value.double_value as string)
+                ) as user_id_raw,
+                property.value.set_timestamp_micros as set_timestamp_micros
+            from unnest(e.user_properties) as property
+            where lower(property.key) = 'user_id'
+            order by to_json_string(property.value)
+            limit 1
+        ) as property_user,
+        (
+            select
+                coalesce(
+                    param.value.string_value,
+                    cast(param.value.int_value as string),
+                    cast(param.value.float_value as string),
+                    cast(param.value.double_value as string)
+                )
+            from unnest(e.event_params) as param
+            where lower(param.key) = 'user_id'
+            order by to_json_string(param.value)
+            limit 1
+        ) as param_user_id_raw,
+        (
+            select
+                coalesce(
+                    param.value.string_value,
+                    cast(param.value.int_value as string),
+                    cast(param.value.float_value as string),
+                    cast(param.value.double_value as string)
+                )
+            from unnest(e.event_params) as param
+            where lower(param.key) = 'gender'
+            order by to_json_string(param.value)
+            limit 1
+        ) as gender_raw,
+        (
+            select
+                coalesce(
+                    param.value.string_value,
+                    cast(param.value.int_value as string),
+                    cast(param.value.float_value as string),
+                    cast(param.value.double_value as string)
+                )
+            from unnest(e.event_params) as param
+            where lower(param.key) = 'major'
+            order by to_json_string(param.value)
+            limit 1
+        ) as major_raw
+    from {{ source('ga4', 'events') }} as e
+    left join existing_users
+        on e.user_pseudo_id = existing_users.user_pseudo_id
+    where regexp_contains(_table_suffix, r'^\d{8}$')
+      and _table_suffix between {{ scan_start_sql }} and {{ scan_end_sql }}
+      and date(timestamp_micros(e.event_timestamp), 'Asia/Seoul') between
+          {{ target_start_sql }} and {{ target_end_sql }}
+      {% if incremental_mode %}
+      and (
+          existing_users.user_pseudo_id is null
+          or datetime(
+              timestamp_micros(e.event_timestamp),
+              'Asia/Seoul'
+          ) > existing_users.last_seen_at
+      )
+      {% endif %}
+
+),
+
+identity_extracted as (
+
+    select
+        stream_id,
+        event_ts,
+        event_at,
+        event_dt,
+        user_pseudo_id,
+        top_user_id_raw,
+        property_user.user_id_raw as property_user_id_raw,
+        property_user.set_timestamp_micros as property_user_id_set_ts,
+        param_user_id_raw,
+        gender_raw,
+        major_raw
+    from source_filtered
+
+),
+
+identifiers_cleaned as (
+
+    select
+        identity_extracted.*,
+        nullif(
+            lower(
+                trim(
+                    regexp_replace(
+                        regexp_replace(
+                            regexp_replace(
+                                top_user_id_raw,
+                                r'[\p{Cc}\p{Zl}\p{Zp}]',
+                                ''
+                            ),
+                            '-',
+                            '_'
+                        ),
+                        r'(?i)_optional\(\s*(\d+)\s*\)\s*$',
+                        r'_\1'
+                    )
+                )
+            ),
+            ''
+        ) as top_user_id_clean,
+        nullif(
+            lower(
+                trim(
+                    regexp_replace(
+                        regexp_replace(
+                            regexp_replace(
+                                property_user_id_raw,
+                                r'[\p{Cc}\p{Zl}\p{Zp}]',
+                                ''
+                            ),
+                            '-',
+                            '_'
+                        ),
+                        r'(?i)_optional\(\s*(\d+)\s*\)\s*$',
+                        r'_\1'
+                    )
+                )
+            ),
+            ''
+        ) as property_user_id_clean,
+        nullif(
+            lower(
+                trim(
+                    regexp_replace(
+                        regexp_replace(
+                            regexp_replace(
+                                param_user_id_raw,
+                                r'[\p{Cc}\p{Zl}\p{Zp}]',
+                                ''
+                            ),
+                            '-',
+                            '_'
+                        ),
+                        r'(?i)_optional\(\s*(\d+)\s*\)\s*$',
+                        r'_\1'
+                    )
+                )
+            ),
+            ''
+        ) as param_user_id_clean,
+        nullif(
+            lower(
+                trim(
+                    regexp_replace(
+                        gender_raw,
+                        r'[\p{Cc}\p{Zl}\p{Zp}]',
+                        ''
+                    )
+                )
+            ),
+            ''
+        ) as gender,
+        nullif(
+            lower(
+                trim(
+                    regexp_replace(
+                        major_raw,
+                        r'[\p{Cc}\p{Zl}\p{Zp}]',
+                        ''
+                    )
+                )
+            ),
+            ''
+        ) as major
+    from identity_extracted
+
+),
+
+identifiers_validated as (
+
+    select
+        identifiers_cleaned.*,
+        case
+            when regexp_contains(
+                top_user_id_clean,
+                r'(?i)(_nil|_null|_0)\s*$'
+            )
+                then null
+            when regexp_contains(
+                top_user_id_clean,
+                r'(?i)^anonymous(?:_\d+)?$'
+            )
+                then top_user_id_clean
+            when regexp_contains(top_user_id_clean, r'^\d{6}_\d+$')
+                then top_user_id_clean
+            else null
+        end as top_user_id,
+        case
+            when regexp_contains(
+                property_user_id_clean,
+                r'(?i)(_nil|_null|_0)\s*$'
+            )
+                then null
+            when regexp_contains(
+                property_user_id_clean,
+                r'(?i)^anonymous(?:_\d+)?$'
+            )
+                then property_user_id_clean
+            when regexp_contains(property_user_id_clean, r'^\d{6}_\d+$')
+                then property_user_id_clean
+            else null
+        end as property_user_id,
+        case
+            when regexp_contains(
+                param_user_id_clean,
+                r'(?i)(_nil|_null|_0)\s*$'
+            )
+                then null
+            when regexp_contains(
+                param_user_id_clean,
+                r'(?i)^anonymous(?:_\d+)?$'
+            )
+                then param_user_id_clean
+            when regexp_contains(param_user_id_clean, r'^\d{6}_\d+$')
+                then param_user_id_clean
+            else null
+        end as param_user_id
+    from identifiers_cleaned
+
+),
+
+identity_resolved as (
+
+    select
+        identifiers_validated.*,
+        coalesce(
+            top_user_id,
+            param_user_id
+        ) as resolved_user_id,
+        case
+            when top_user_id is not null then 'header'
+            when param_user_id is not null then 'event_param'
+            else null
+        end as user_id_source
+    from identifiers_validated
+    where user_pseudo_id is not null
+
+),
+
+identity_observation_prepared as (
+
+    select
+        identity_resolved.*,
+        to_json_string(
+            struct(
+                stream_id as stream_id,
+                user_pseudo_id as user_pseudo_id,
+                event_ts as event_ts,
+                top_user_id as top_user_id,
+                property_user_id as property_user_id,
+                param_user_id as param_user_id,
+                gender as gender,
+                major as major
+            )
+        ) as identity_observation_json
+    from identity_resolved
+
+),
+
+identity_observations_deduped as (
+
+    select
+        identity_observation_prepared.*,
+        to_hex(sha256(identity_observation_json)) as identity_observation_id
+    from identity_observation_prepared
+    qualify row_number() over (
+        partition by to_hex(sha256(identity_observation_json))
+        order by
+            event_at,
+            coalesce(property_user_id_set_ts, 0)
+    ) = 1
+
+),
+
+daily_identity_states as (
+
+    select
+        event_dt,
+        stream_id,
+        user_pseudo_id,
+        top_user_id,
+        property_user_id,
+        param_user_id,
+        resolved_user_id,
+        user_id_source,
+        gender,
+        major,
+        min(event_at) as first_seen_at,
+        max(event_at) as last_seen_at,
+        min(property_user_id_set_ts) as property_user_id_set_ts,
+        count(*) as source_event_count
+    from identity_observations_deduped
+    group by
+        event_dt,
+        stream_id,
+        user_pseudo_id,
+        top_user_id,
+        property_user_id,
+        param_user_id,
+        resolved_user_id,
+        user_id_source,
+        gender,
+        major
+
+),
+
+recent_candidate_states as (
+
+    select
+        daily_identity_states.*,
+        source_event_count as base_user_id_support_count,
+        to_hex(
+            sha256(
+                to_json_string(
+                    struct(
+                        event_dt as event_dt,
+                        stream_id as stream_id,
+                        user_pseudo_id as user_pseudo_id,
+                        top_user_id as top_user_id,
+                        property_user_id as property_user_id,
+                        param_user_id as param_user_id,
+                        gender as gender,
+                        major as major
+                    )
+                )
+            )
+        ) as user_identity_state_id
+    from daily_identity_states
+
+),
+
+existing_candidate_states as (
+
+    select
+        date(last_seen_at) as event_dt,
+        stream_id,
+        user_pseudo_id,
+        top_user_id,
+        property_user_id,
+        param_user_id,
+        user_id as resolved_user_id,
+        user_id_source,
+        gender,
+        major,
+        first_seen_at,
+        last_seen_at,
+        property_user_id_set_ts,
+        source_event_count,
+        user_id_support_count as base_user_id_support_count,
+        to_hex(
+            sha256(
+                to_json_string(
+                    struct(
+                        'existing' as state_origin,
+                        user_pseudo_id as user_pseudo_id,
+                        user_id as user_id,
+                        last_seen_at as last_seen_at
+                    )
+                )
+            )
+        ) as user_identity_state_id
+    from existing_users
+
+),
+
+all_candidate_states as (
+
+    select * from existing_candidate_states
+    union all
+    select * from recent_candidate_states
+
+),
+
+candidate_prepared as (
+
+    select
+        all_candidate_states.*,
+        case
+            when resolved_user_id is null then 2
+            when regexp_contains(
+                resolved_user_id,
+                r'(?i)^anonymous(?:_\d+)?$'
+            )
+                then 1
+            else 0
+        end as user_id_priority,
+        case user_id_source
+            when 'header' then 0
+            when 'event_param' then 1
+            else 2
+        end as user_id_source_priority,
+        coalesce(
+            cast(
+                regexp_contains(resolved_user_id, r'^\d{6}_\d+$')
+                as int64
+            ),
+            0
+        )
+            + cast(gender is not null as int64)
+            + cast(major is not null as int64) as completeness
+    from all_candidate_states
+
+),
+
+candidate_scored as (
+
+    select
+        candidate_prepared.*,
+        sum(base_user_id_support_count) over (
+            partition by user_pseudo_id, resolved_user_id
+        ) as user_id_support_count,
+        max(completeness) over (
+            partition by user_pseudo_id, resolved_user_id
+        ) as user_id_completeness,
+        max(last_seen_at) over (
+            partition by user_pseudo_id, resolved_user_id
+        ) as user_id_latest_seen_at
+    from candidate_prepared
+
+),
+
+canonical_observation as (
+
+    select *
+    from candidate_scored
+    qualify row_number() over (
+        partition by user_pseudo_id
+        order by
+            user_id_priority,
+            user_id_source_priority,
+            user_id_completeness desc,
+            user_id_support_count desc,
+            user_id_latest_seen_at desc,
+            last_seen_at desc,
+            user_identity_state_id
+    ) = 1
+
+),
+
+latest_attributes as (
+
+    select
+        user_pseudo_id,
+        array_agg(
+            gender ignore nulls
+            order by last_seen_at desc, user_identity_state_id
+            limit 1
+        )[safe_offset(0)] as gender,
+        array_agg(
+            major ignore nulls
+            order by last_seen_at desc, user_identity_state_id
+            limit 1
+        )[safe_offset(0)] as major
+    from all_candidate_states
+    group by user_pseudo_id
+
+),
+
+user_lifetime as (
+
+    select
+        user_pseudo_id,
+        min(first_seen_at) as first_seen_at,
+        max(last_seen_at) as last_seen_at,
+        sum(source_event_count) as source_event_count
+    from all_candidate_states
+    group by user_pseudo_id
+
+),
+
+ga4_users as (
+
+    select
+        canonical_observation.user_pseudo_id,
+        canonical_observation.stream_id,
+        canonical_observation.resolved_user_id as user_id,
+        canonical_observation.user_id_source,
+        canonical_observation.top_user_id,
+        canonical_observation.property_user_id,
+        canonical_observation.param_user_id,
+        coalesce(
+            canonical_observation.gender,
+            latest_attributes.gender
+        ) as gender,
+        coalesce(
+            canonical_observation.major,
+            latest_attributes.major
+        ) as major,
+        safe_cast(
+            regexp_extract(
+                canonical_observation.resolved_user_id,
+                r'^(20\d{2})'
+            )
+            as int64
+        ) as entry_year,
+        user_lifetime.first_seen_at,
+        user_lifetime.last_seen_at,
+        canonical_observation.user_id_support_count,
+        user_lifetime.source_event_count,
+        canonical_observation.property_user_id_set_ts,
+        safe_cast(
+            regexp_extract(
+                canonical_observation.resolved_user_id,
+                r'_(\d+)\s*$'
+            )
+            as int64
+        ) as user_id_mysql
+    from canonical_observation
+    left join latest_attributes using (user_pseudo_id)
+    left join user_lifetime using (user_pseudo_id)
+
+),
+
+mysql_users as (
+
+    select
+        safe_cast(id as int64) as id,
+        user_type,
+        cast(created_at as timestamp) as signup_completed_at,
+        safe_cast(is_deleted as int64) as is_deleted
+    from {{ source('app_db', 'koin_users') }}
+
+),
+
+final as (
+
+    select
+        ga4_users.user_pseudo_id,
+        ga4_users.stream_id,
+        ga4_users.user_id,
+        ga4_users.user_id_source,
+        ga4_users.top_user_id,
+        ga4_users.property_user_id,
+        ga4_users.param_user_id,
+        ga4_users.gender,
+        ga4_users.major,
+        ga4_users.entry_year,
+        ga4_users.first_seen_at,
+        ga4_users.last_seen_at,
+        ga4_users.user_id_support_count,
+        ga4_users.source_event_count,
+        ga4_users.property_user_id_set_ts,
+        mysql_users.user_type,
+        mysql_users.signup_completed_at,
+        mysql_users.is_deleted,
+        mysql_users.id is not null as is_mysql_mapped
+    from ga4_users
+    left join mysql_users
+        on ga4_users.user_id_mysql = mysql_users.id
+
+)
+
+select *
+from final

--- a/dbt/models/silver/silver_events_v2.sql
+++ b/dbt/models/silver/silver_events_v2.sql
@@ -1,0 +1,992 @@
+{#-
+  최종 Silver 이벤트 계약의 운영 V2 모델.
+  날짜 처리와 모델 설정은 현재 Lightsail 운영 silver_events의 원본 흐름을 따른다.
+
+  처리 범위는 호출자(Airflow 또는 사람)가 정한다.
+
+    * 기본     : vars 없이 실행하면 최근 3일(어제 기준)을 다시 계산해 교체
+    * 범위 지정: dbt run --vars '{"start_date":"YYYYMMDD","end_date":"YYYYMMDD"}'
+    * 전체 적재: 분석 시작일을 명시한다
+                 --vars '{"start_date":"20240711","end_date":"YYYYMMDD"}'
+
+  개선 후보 (원본 동작을 유지하기 위해 현재는 적용하지 않음):
+
+    * Airflow 실행은 항상 start_date/end_date를 넘겨 재시도·백필 범위를 고정한다.
+      현재 live dbt_ga4_daily도 이 방식으로 실행한다.
+    * insert_overwrite는 결과가 0건인 요청일의 기존 파티션을 자동으로 비우지 않는다.
+      날짜 계약과 Cosmos 파싱을 함께 검증한 뒤 정적 partitions 설정을 다시 도입할 수 있다.
+    * GA4 원천부터 독립적으로 계산하므로 기존 silver_events를 참조하지 않는다.
+-#}
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='insert_overwrite',
+        partition_by={
+            'field': 'event_dt',
+            'data_type': 'date',
+            'granularity': 'day'
+        },
+        cluster_by=['event_id', 'user_pseudo_id', 'event_name'],
+        on_schema_change='fail'
+    )
+}}
+
+{% set ANALYSIS_START_DATE = '20240711' %}
+{% set LOOKBACK_DAYS = 3 %}
+{% set SIGNUP_LOOKBACK_MINUTES = 15 %}
+
+{% set start_date_var = var('start_date', none) %}
+{% set end_date_var = var('end_date', none) %}
+{% set start_date = start_date_var | string if start_date_var is not none else none %}
+{% set end_date = end_date_var | string if end_date_var is not none else none %}
+
+{#-
+  안전 보완: 두 값은 SQL 리터럴로 직접 삽입되므로 숫자 8자리만 허용한다.
+  길이만 검사하면 `1' or '1`처럼 8자짜리 문자열이 통과해 SQL을 벗어날 수 있다.
+  값이 없을 때는 오류를 내지 않아 Cosmos의 dbt ls 파싱도 허용한다.
+-#}
+{% if (start_date and not end_date) or (end_date and not start_date) %}
+    {{ exceptions.raise_compiler_error('start_date와 end_date는 반드시 함께 지정해야 합니다.') }}
+{% endif %}
+
+{% if start_date and end_date %}
+    {% for value in [start_date, end_date] %}
+        {% if not modules.re.match('^[0-9]{8}$', value) %}
+            {{ exceptions.raise_compiler_error(
+                "start_date와 end_date는 숫자 8자리(YYYYMMDD)여야 합니다. 받은 값: '" ~ value ~ "'"
+            ) }}
+        {% endif %}
+    {% endfor %}
+    {% if start_date > end_date %}
+        {{ exceptions.raise_compiler_error('start_date가 end_date보다 늦을 수 없습니다.') }}
+    {% endif %}
+{% endif %}
+
+{% if start_date and end_date %}
+    {% set target_start_sql = "parse_date('%Y%m%d', '" ~ start_date ~ "')" %}
+    {% set target_end_sql = "parse_date('%Y%m%d', '" ~ end_date ~ "')" %}
+{% else %}
+    {% set target_start_sql = "date_sub(current_date('Asia/Seoul'), interval " ~ LOOKBACK_DAYS ~ " day)" %}
+    {% set target_end_sql = "date_sub(current_date('Asia/Seoul'), interval 1 day)" %}
+{% endif %}
+
+{#-
+  Android 가입 세션은 시작 시각보다 앞선 이벤트를 상속해야 하므로 범위 앞쪽을
+  SIGNUP_LOOKBACK_MINUTES만큼 더 읽는다. 그 lookback이 자정을 넘어 전날 테이블로
+  넘어갈 수 있어 스캔 범위도 하루 더 넓힌다.
+  분석 시작일에는 앞선 데이터 자체가 없으므로 둘 다 적용하지 않는다.
+-#}
+{% set apply_signup_lookback = start_date != ANALYSIS_START_DATE %}
+
+{% if apply_signup_lookback %}
+    {% set scan_start_sql = "format_date('%Y%m%d', date_sub(" ~ target_start_sql ~ ", interval 1 day))" %}
+{% else %}
+    {% set scan_start_sql = "'" ~ ANALYSIS_START_DATE ~ "'" %}
+{% endif %}
+
+{#- 날짜를 명시받았으면 리터럴로 둔다. BigQuery가 스캔할 테이블을 더 확실히 줄인다. -#}
+{% if end_date %}
+    {% set scan_end_sql = "'" ~ end_date ~ "'" %}
+{% else %}
+    {% set scan_end_sql = "format_date('%Y%m%d', " ~ target_end_sql ~ ")" %}
+{% endif %}
+
+with date_window as (
+
+    select
+        {{ target_start_sql }} as target_start_dt,
+        {{ target_end_sql }} as target_end_dt
+
+),
+
+input_window as (
+
+    select
+        target_start_dt,
+        target_end_dt,
+        {% if apply_signup_lookback %}
+        datetime_sub(
+            datetime(target_start_dt, time '00:00:00'),
+            interval {{ SIGNUP_LOOKBACK_MINUTES }} minute
+        ) as input_start_at,
+        {% else %}
+        datetime(target_start_dt, time '00:00:00') as input_start_at,
+        {% endif %}
+        datetime(
+            date_add(target_end_dt, interval 1 day),
+            time '00:00:00'
+        ) as input_end_at
+    from date_window
+
+),
+
+-- 확정 일별 테이블만 읽는다. intraday 테이블은 별도의 실시간 요구가 생길 때 분리한다.
+source_filtered as (
+
+    select
+        e as raw_event,
+        _table_suffix as source_table_suffix
+    from {{ source('ga4', 'events') }} as e
+    cross join input_window as input_range
+    -- _table_suffix 조건은 BigQuery가 스캔할 테이블을 미리 줄이도록
+    -- CTE 값이 아닌 상수 식으로 직접 쓴다.
+    where regexp_contains(_table_suffix, r'^\d{8}$')
+      and _table_suffix between {{ scan_start_sql }} and {{ scan_end_sql }}
+      and datetime(timestamp_micros(e.event_timestamp), 'Asia/Seoul') >= input_range.input_start_at
+      and datetime(timestamp_micros(e.event_timestamp), 'Asia/Seoul') < input_range.input_end_at
+
+),
+
+-- raw_event_id와 event_id 해시에서는 값 타입과 무관한 문자열 변환을 하지 않는다.
+source_canonicalized as (
+
+    select
+        source_filtered.*,
+        array(
+            select as struct
+                param.key,
+                param.value
+            from unnest(source_filtered.raw_event.event_params) as param
+            order by
+                param.key,
+                to_json_string(param.value)
+        ) as canonical_event_params
+    from source_filtered
+
+),
+
+-- event_params 배열 순서만 다른 동일 raw row를 같은 payload로 취급한다.
+source_payload_canonicalized as (
+
+    select
+        source_canonicalized.*,
+        to_json_string(
+            struct(
+                to_json_string(
+                    (select as struct raw_event.* except (event_params))
+                ) as non_param_payload,
+                canonical_event_params as event_params
+            )
+        ) as canonical_payload_json
+    from source_canonicalized
+
+),
+
+-- 전송·배치 위치와 canonical event_params를 raw event의 물리 식별 정보로 사용한다.
+raw_identity_prepared as (
+
+    select
+        source_payload_canonicalized.*,
+        to_json_string(
+            struct(
+                raw_event.stream_id as stream_id,
+                raw_event.user_pseudo_id as user_pseudo_id,
+                raw_event.event_bundle_sequence_id as event_bundle_sequence_id,
+                raw_event.event_server_timestamp_offset as event_server_timestamp_offset,
+                raw_event.batch_page_id as batch_page_id,
+                raw_event.batch_ordering_id as batch_ordering_id,
+                raw_event.batch_event_index as batch_event_index,
+                canonical_event_params as event_params
+            )
+        ) as raw_identity_json
+    from source_payload_canonicalized
+
+),
+
+raw_keyed as (
+
+    select
+        raw_identity_prepared.*,
+        to_hex(sha256(raw_identity_json)) as raw_event_id
+    from raw_identity_prepared
+
+),
+
+raw_key_stats as (
+
+    select
+        raw_event_id,
+        count(distinct raw_identity_json) as raw_identity_variant_count
+    from raw_keyed
+    group by raw_event_id
+
+),
+
+-- 같은 해시가 서로 다른 raw identity를 가리키면 제거하지 않고 모델을 실패시킨다.
+raw_validated as (
+
+    select raw_keyed.*
+    from raw_keyed
+    inner join raw_key_stats using (raw_event_id)
+    where if(
+        raw_identity_variant_count = 1,
+        true,
+        error(format('raw_event_id %s maps to multiple raw identities', raw_event_id))
+    )
+
+),
+
+-- 물리 Bronze 테이블을 만들지 않는 대신 이 CTE에서 원천 물리 중복을 제거한다.
+bronze_deduped as (
+
+    select *
+    from raw_validated
+    qualify row_number() over (
+        partition by raw_event_id
+        order by
+            canonical_payload_json,
+            source_table_suffix
+    ) = 1
+
+),
+
+event_identity_prepared as (
+
+    select
+        bronze_deduped.*,
+        to_json_string(
+            struct(
+                raw_event.stream_id as stream_id,
+                raw_event.user_pseudo_id as user_pseudo_id,
+                raw_event.event_timestamp as event_timestamp,
+                raw_event.event_name as event_name,
+                raw_event.event_bundle_sequence_id as event_bundle_sequence_id,
+                raw_event.batch_event_index as batch_event_index,
+                canonical_event_params as event_params
+            )
+        ) as event_identity_json
+    from bronze_deduped
+
+),
+
+event_keyed as (
+
+    select
+        event_identity_prepared.*,
+        to_hex(
+            sha256(event_identity_json)
+        ) as event_id
+    from event_identity_prepared
+
+),
+
+event_key_stats as (
+
+    select
+        event_id,
+        count(distinct event_identity_json) as identity_variant_count
+    from event_keyed
+    group by event_id
+
+),
+
+-- 같은 해시가 서로 다른 event identity를 가리키면 논리 중복으로 축약하지 않는다.
+event_validated as (
+
+    select event_keyed.*
+    from event_keyed
+    inner join event_key_stats using (event_id)
+    where if(
+        identity_variant_count = 1,
+        true,
+        error(format('event_id %s maps to multiple event identities', event_id))
+    )
+
+),
+
+-- 추후 event_id -> 전체 raw_event_id 계보 모델이 필요하면 이 CTE를 분기점으로 사용한다.
+event_lineage_candidate as (
+
+    select *
+    from event_validated
+
+),
+
+silver_deduped as (
+
+    select *
+    from event_lineage_candidate
+    qualify row_number() over (
+        partition by event_id
+        order by raw_event_id
+    ) = 1
+
+),
+
+-- 중복 제거가 모두 끝난 뒤에만 event_params를 펼친다.
+params_unnested as (
+
+    select
+        silver_deduped.raw_event_id,
+        silver_deduped.event_id,
+        silver_deduped.raw_event.event_timestamp as event_ts,
+        datetime(
+            timestamp_micros(silver_deduped.raw_event.event_timestamp),
+            'Asia/Seoul'
+        ) as event_at,
+        date(
+            timestamp_micros(silver_deduped.raw_event.event_timestamp),
+            'Asia/Seoul'
+        ) as event_dt,
+        silver_deduped.raw_event.event_name as event_name,
+        silver_deduped.raw_event.user_pseudo_id as user_pseudo_id,
+        silver_deduped.raw_event.platform as platform,
+        silver_deduped.raw_event.device.category as device_category,
+        silver_deduped.raw_event.device.operating_system as device_os,
+        silver_deduped.raw_event.device.operating_system_version as device_os_version,
+        silver_deduped.raw_event.event_bundle_sequence_id as event_bundle_sequence_id,
+        silver_deduped.raw_event.batch_ordering_id as batch_ordering_id,
+        silver_deduped.raw_event.batch_event_index as batch_event_index,
+        param.key as param_key,
+        param.value as param_value,
+        param_offset
+    from silver_deduped
+    left join unnest(silver_deduped.canonical_event_params) as param
+        with offset as param_offset
+        on true
+
+),
+
+param_values as (
+
+    select
+        params_unnested.*,
+        coalesce(
+            param_value.string_value,
+            cast(param_value.int_value as string),
+            cast(param_value.float_value as string),
+            cast(param_value.double_value as string)
+        ) as param_value_as_string
+    from params_unnested
+
+),
+
+-- 같은 key가 반복되면 canonical 정렬 기준의 첫 번째 값을 결정적으로 사용한다.
+params_first_occurrence as (
+
+    select *
+    from param_values
+    qualify
+        param_key is null
+        or row_number() over (
+            partition by event_id, param_key
+            order by param_offset
+        ) = 1
+
+),
+
+params_pivoted as (
+
+    select
+        raw_event_id,
+        event_id,
+        event_dt,
+        event_at,
+        event_ts,
+        event_name,
+        user_pseudo_id,
+        platform,
+        device_category,
+        device_os,
+        device_os_version,
+        event_bundle_sequence_id,
+        batch_ordering_id,
+        batch_event_index,
+        max(if(param_key = 'ga_session_id', param_value_as_string, null)) as ga_session_id,
+        max(if(param_key = 'custom_session_id', param_value_as_string, null)) as custom_session_id,
+        max(if(param_key = 'event_label', param_value_as_string, null)) as event_label,
+        max(if(param_key = 'event_category', param_value_as_string, null)) as event_category,
+        max(if(param_key = 'value', param_value_as_string, null)) as event_value,
+        max(if(param_key = 'page_title', param_value_as_string, null)) as page_title,
+        max(if(param_key = 'page_location', param_value_as_string, null)) as page_location,
+        max(if(param_key = 'screen_name', param_value_as_string, null)) as raw_screen_name,
+        max(if(param_key = 'firebase_screen_class', param_value_as_string, null)) as raw_firebase_screen_class,
+        max(
+            if(
+                param_key = 'engagement_time_msec',
+                safe_cast(param_value_as_string as int64),
+                null
+            )
+        ) as engagement_time_msec
+    from params_first_occurrence
+    group by
+        raw_event_id,
+        event_id,
+        event_dt,
+        event_at,
+        event_ts,
+        event_name,
+        user_pseudo_id,
+        platform,
+        device_category,
+        device_os,
+        device_os_version,
+        event_bundle_sequence_id,
+        batch_ordering_id,
+        batch_event_index
+
+),
+
+normalized as (
+
+    select
+        params_pivoted.* except (raw_screen_name, raw_firebase_screen_class),
+        case
+            when raw_screen_name in ('HomeActivity', 'ShopActivity', 'ShopDetailActivity')
+                then raw_screen_name
+            when raw_firebase_screen_class like '%MainActivity%'
+                then 'HomeActivity'
+            when raw_firebase_screen_class like '%StoreDetailActivity%'
+                then 'ShopDetailActivity'
+            when raw_firebase_screen_class like '%StoreActivity%'
+                then 'ShopActivity'
+            else raw_firebase_screen_class
+        end as screen_class
+    from params_pivoted
+
+),
+
+-- 전체 서비스/퍼널 매핑 대신 가입 세션 보정에 필요한 최소 단계만 계산한다.
+signup_stage as (
+
+    select
+        normalized.*,
+        case
+            when lower(trim(coalesce(event_label, ''))) = 'sign_up_completed'
+                then 'signup_complete'
+            when lower(trim(coalesce(event_label, ''))) = 'create_account'
+                then 'form_entry'
+            when lower(trim(coalesce(event_label, ''))) = 'identity_verification'
+                then 'identity_verification'
+            when lower(trim(coalesce(event_label, ''))) = 'terms_agreement'
+                then 'terms_agreement'
+            when lower(trim(coalesce(event_value, ''))) = '회원가입 시작'
+                then 'signup_start'
+            else null
+        end as signup_stage
+    from normalized
+
+),
+
+signup_candidates as (
+
+    select
+        staged.*,
+        last_value(
+            if(
+                staged.signup_stage = 'signup_start',
+                struct(
+                    staged.event_ts as anchor_event_ts,
+                    staged.custom_session_id as anchor_custom_session_id
+                ),
+                null
+            ) ignore nulls
+        ) over (
+            partition by staged.user_pseudo_id
+            order by
+                staged.event_ts,
+                coalesce(staged.event_bundle_sequence_id, -1),
+                coalesce(staged.batch_ordering_id, -1),
+                coalesce(staged.batch_event_index, -1),
+                staged.event_id
+            rows between unbounded preceding and current row
+        ) as anchor_start
+    from signup_stage as staged
+    where staged.platform = 'ANDROID'
+      and staged.user_pseudo_id is not null
+      and staged.signup_stage is not null
+
+),
+
+signup_candidates_localized as (
+
+    select
+        signup_candidates.* except (anchor_start),
+        anchor_start.anchor_event_ts as anchor_start_event_ts,
+        anchor_start.anchor_custom_session_id as anchor_custom_session_id,
+        datetime(
+            timestamp_micros(anchor_start.anchor_event_ts),
+            'Asia/Seoul'
+        ) as anchor_start_at
+    from signup_candidates
+
+),
+
+-- 최신 가입 시작의 기존 ID를 우선 상속하고, 없을 때만 Dataform 호환 ID를 생성한다.
+signup_session_fills as (
+
+    select
+        event_id,
+        coalesce(
+            anchor_custom_session_id,
+            concat(
+                'sign_up_strict_',
+                cast(unix_seconds(timestamp(anchor_start_at)) as string),
+                '_',
+                upper(
+                    substr(
+                        to_hex(
+                            md5(
+                                concat(
+                                    user_pseudo_id,
+                                    cast(anchor_start_at as string)
+                                )
+                            )
+                        ),
+                        1,
+                        5
+                    )
+                )
+            )
+        ) as filled_custom_session_id
+    from signup_candidates_localized
+    where custom_session_id is null
+      and anchor_start_event_ts is not null
+      and event_ts between anchor_start_event_ts and anchor_start_event_ts + (15 * 60 * 1000000)
+
+),
+
+signup_sessionized as (
+
+    select
+        staged.* except (
+            custom_session_id,
+            signup_stage,
+            event_bundle_sequence_id,
+            batch_ordering_id,
+            batch_event_index
+        ),
+        coalesce(
+            staged.custom_session_id,
+            signup_session_fills.filled_custom_session_id
+        ) as custom_session_id
+    from signup_stage as staged
+    left join signup_session_fills using (event_id)
+
+),
+
+final_target_dates as (
+
+    select
+        signup_sessionized.event_id,
+        signup_sessionized.event_dt,
+        signup_sessionized.event_at,
+        signup_sessionized.event_ts,
+        signup_sessionized.event_name,
+        signup_sessionized.user_pseudo_id,
+        signup_sessionized.ga_session_id,
+        signup_sessionized.custom_session_id,
+        signup_sessionized.platform,
+        signup_sessionized.device_category,
+        signup_sessionized.device_os,
+        signup_sessionized.device_os_version,
+        signup_sessionized.event_label,
+        signup_sessionized.event_category,
+        signup_sessionized.event_value,
+        signup_sessionized.page_title,
+        signup_sessionized.screen_class,
+        signup_sessionized.engagement_time_msec,
+        signup_sessionized.page_location
+    from signup_sessionized
+    cross join date_window
+    where signup_sessionized.event_dt between date_window.target_start_dt and date_window.target_end_dt
+
+),
+
+analytics_normalized as (
+
+    select
+        final_target_dates.*,
+        nullif(lower(trim(event_label)), '') as event_label_norm,
+        nullif(lower(trim(event_value)), '') as event_value_norm,
+        nullif(lower(trim(page_title)), '') as page_title_norm,
+        nullif(lower(trim(screen_class)), '') as screen_class_norm
+    from final_target_dates
+
+),
+
+-- 기존 Dataform 서비스 매핑의 우선순위를 CASE 순서로 고정한다.
+service_mapped as (
+
+    select
+        analytics_normalized.*,
+        case
+            when event_label_norm in (
+                'popular_notice',
+                'notice_hot',
+                'notice_original_shortcut',
+                'notice_tab',
+                'notice_search',
+                'notice_search_event',
+                'main_notice',
+                'main_notice_detail'
+            )
+                or (
+                    event_label_norm in ('hamburger', 'header', 'footer')
+                    and event_value_norm = '게시판'
+                )
+                then 'board'
+
+            when event_label_norm = 'shop_call'
+                or screen_class_norm like '%shopviewcontroller%'
+                or screen_class_norm like '%shopdataviewcontroller%'
+                or screen_class_norm = 'shopsummaryviewcontroller'
+                or screen_class_norm = 'shopactivity'
+                or screen_class_norm = 'shopdetailactivity'
+                or page_title_norm = '코인 - 상점 상세'
+                or event_label_norm = 'main_shop_categories'
+                or (
+                    event_label_norm in ('hamburger', 'header', 'footer')
+                    and event_value_norm = '주변상점'
+                )
+                then 'shop'
+
+            when event_label_norm in (
+                'menu_share',
+                'menu_time',
+                'main_menu_movedetailview',
+                'main_menu_corner'
+            )
+                or (
+                    event_label_norm in ('hamburger', 'header', 'footer')
+                    and event_value_norm = '식단'
+                )
+                then 'cafeteria'
+
+            when event_label_norm in (
+                'search_bus',
+                'departure_location_confirm',
+                'arrival_location_confirm',
+                'main_bus_search'
+            )
+                or (
+                    event_label_norm in ('hamburger', 'header', 'footer')
+                    and event_value_norm in ('버스 시간표', '교통편 조회하기')
+                )
+                then 'bus'
+
+            when event_label_norm in (
+                'club_tab_select',
+                'club_main_select',
+                'club_main_category',
+                'main_club',
+                'main_popular_club'
+            )
+                or (
+                    event_label_norm in ('hamburger', 'header', 'footer')
+                    and event_value_norm = '동아리'
+                )
+                then 'club'
+
+            when event_label_norm in ('main_modal', 'main_modal_entry')
+                then 'banner'
+
+            when event_label_norm in ('hamburger', 'header', 'footer')
+                and event_value_norm = '교내 시설물 정보'
+                then 'facility'
+
+            when event_label_norm in ('timetable', 'main_timetable')
+                or (
+                    event_label_norm in ('hamburger', 'header', 'footer')
+                    and event_value_norm = '시간표'
+                )
+                or event_value_norm in ('search', '이미지저장')
+                or event_value_norm like 'click_semester_%'
+                or event_value_norm like 'click_currirculum_%'
+                or event_value_norm like 'click_curriculum_%'
+                then 'timetable'
+
+            when event_label_norm in (
+                'graduation_calculator',
+                'graduation_calculator_department',
+                'graduation_calculator_semester',
+                'graduation_calculator_edit_timetable',
+                'graduation_calculator_delete_lecture',
+                'graduation_calculator_add_excel',
+                'graduation_calculator_liberal_arts_list',
+                'graduation_calculator_completion_category',
+                'graduation_calculator_lectures_list'
+            )
+                then 'grad_calc'
+
+            when event_label_norm in (
+                'login',
+                'terms_agreement',
+                'identity_verification',
+                'create_account',
+                'sign_up_completed'
+            )
+                or event_value_norm = '회원가입 시작'
+                or (
+                    event_label_norm in ('hamburger', 'header', 'footer')
+                    and event_value_norm in ('로그인', '회원가입', '정보수정')
+                )
+                then 'account'
+
+            when page_title_norm = '코인 - 한기대 커뮤니티'
+                or screen_class_norm like '%homeviewcontroller%'
+                or screen_class_norm like '%mainactivity%'
+                then 'main'
+
+            else 'unmapped'
+        end as service_name
+    from analytics_normalized
+
+),
+
+funnel_mapped as (
+
+    select
+        service_mapped.*,
+        case
+            when service_name = 'board'
+                and event_label_norm in (
+                    'popular_notice',
+                    'notice_hot',
+                    'notice_original_shortcut'
+                )
+                then 'read'
+            when service_name = 'board'
+                and event_label_norm in (
+                    'notice_tab',
+                    'notice_search',
+                    'notice_search_event'
+                )
+                then 'explore'
+            when service_name = 'board'
+                and (
+                    event_label_norm in ('main_notice', 'main_notice_detail')
+                    or (
+                        event_label_norm in ('hamburger', 'header', 'footer')
+                        and event_value_norm = '게시판'
+                    )
+                )
+                then 'entry'
+
+            when service_name = 'shop' and event_label_norm = 'shop_call'
+                then 'call'
+            when service_name = 'shop'
+                and (
+                    screen_class_norm like '%shopdataviewcontroller%'
+                    or screen_class_norm = 'shopsummaryviewcontroller'
+                    or screen_class_norm = 'shopdetailactivity'
+                    or page_title_norm = '코인 - 상점 상세'
+                )
+                then 'shop_view'
+            when service_name = 'shop'
+                and (
+                    event_label_norm = 'main_shop_categories'
+                    or (
+                        event_label_norm in ('hamburger', 'header', 'footer')
+                        and event_value_norm = '주변상점'
+                    )
+                    or screen_class_norm like '%shopviewcontroller%'
+                    or screen_class_norm = 'shopactivity'
+                )
+                then 'entry'
+
+            when service_name = 'cafeteria' and event_label_norm = 'menu_share'
+                then 'share'
+            when service_name = 'cafeteria' and event_label_norm = 'menu_time'
+                then 'explore'
+            when service_name = 'cafeteria'
+                and (
+                    event_label_norm in ('main_menu_movedetailview', 'main_menu_corner')
+                    or (
+                        event_label_norm in ('hamburger', 'header', 'footer')
+                        and event_value_norm = '식단'
+                    )
+                )
+                then 'entry'
+
+            when service_name = 'bus' and event_label_norm = 'search_bus'
+                then 'search'
+            when service_name = 'bus'
+                and event_label_norm in (
+                    'departure_location_confirm',
+                    'arrival_location_confirm'
+                )
+                then 'set_od'
+            when service_name = 'bus'
+                and (
+                    event_label_norm = 'main_bus_search'
+                    or (
+                        event_label_norm in ('hamburger', 'header', 'footer')
+                        and event_value_norm in ('버스 시간표', '교통편 조회하기')
+                    )
+                )
+                then 'entry'
+
+            when service_name = 'club' and event_label_norm = 'club_tab_select'
+                then 'detail'
+            when service_name = 'club' and event_label_norm = 'club_main_select'
+                then 'club_view'
+            when service_name = 'club' and event_label_norm = 'club_main_category'
+                then 'explore'
+            when service_name = 'club'
+                and (
+                    event_label_norm in ('main_club', 'main_popular_club')
+                    or (
+                        event_label_norm in ('hamburger', 'header', 'footer')
+                        and event_value_norm = '동아리'
+                    )
+                )
+                then 'entry'
+
+            when service_name = 'banner' and event_label_norm = 'main_modal'
+                then 'click'
+            when service_name = 'banner' and event_label_norm = 'main_modal_entry'
+                then 'impression'
+
+            when service_name = 'facility'
+                and event_label_norm in ('hamburger', 'header', 'footer')
+                and event_value_norm = '교내 시설물 정보'
+                then 'entry'
+
+            when service_name = 'timetable' and event_value_norm = '이미지저장'
+                then 'save'
+            when service_name = 'timetable'
+                and (
+                    event_value_norm = 'search'
+                    or event_value_norm like 'click_semester_%'
+                    or event_value_norm like 'click_currirculum_%'
+                    or event_value_norm like 'click_curriculum_%'
+                )
+                then 'explore'
+            when service_name = 'timetable'
+                and (
+                    event_label_norm in ('timetable', 'main_timetable')
+                    or (
+                        event_label_norm in ('hamburger', 'header', 'footer')
+                        and event_value_norm = '시간표'
+                    )
+                )
+                then 'entry'
+
+            when service_name = 'grad_calc'
+                and event_label_norm in (
+                    'graduation_calculator_department',
+                    'graduation_calculator_semester',
+                    'graduation_calculator_edit_timetable',
+                    'graduation_calculator_delete_lecture',
+                    'graduation_calculator_add_excel',
+                    'graduation_calculator_liberal_arts_list',
+                    'graduation_calculator_completion_category',
+                    'graduation_calculator_lectures_list'
+                )
+                then 'explore'
+            when service_name = 'grad_calc'
+                and event_label_norm = 'graduation_calculator'
+                then 'entry'
+
+            when service_name = 'account' and event_label_norm = 'sign_up_completed'
+                then 'signup_complete'
+            when service_name = 'account' and event_label_norm = 'create_account'
+                then 'form_entry'
+            when service_name = 'account'
+                and event_label_norm = 'identity_verification'
+                then 'identity_verification'
+            when service_name = 'account' and event_label_norm = 'terms_agreement'
+                then 'terms_agreement'
+            when service_name = 'account' and event_value_norm = '회원가입 시작'
+                then 'signup_start'
+            when service_name = 'account'
+                and (
+                    event_label_norm = 'login'
+                    or (
+                        event_label_norm in ('hamburger', 'header', 'footer')
+                        and event_value_norm in ('로그인', '회원가입', '정보수정')
+                    )
+                )
+                then 'login_entry'
+
+            when service_name = 'main'
+                then 'main'
+
+            else null
+        end as funnel_stage
+    from service_mapped
+
+),
+
+step_order_mapped as (
+
+    select
+        funnel_mapped.*,
+        case
+            when service_name = 'board' and funnel_stage = 'read' then 3
+            when service_name = 'board' and funnel_stage = 'explore' then 2
+            when service_name = 'board' and funnel_stage = 'entry' then 1
+
+            when service_name = 'shop' and funnel_stage = 'call' then 3
+            when service_name = 'shop' and funnel_stage = 'shop_view' then 2
+            when service_name = 'shop' and funnel_stage = 'entry' then 1
+
+            when service_name = 'cafeteria' and funnel_stage = 'share' then 3
+            when service_name = 'cafeteria' and funnel_stage = 'explore' then 2
+            when service_name = 'cafeteria' and funnel_stage = 'entry' then 1
+
+            when service_name = 'bus' and funnel_stage = 'search' then 3
+            when service_name = 'bus' and funnel_stage = 'set_od' then 2
+            when service_name = 'bus' and funnel_stage = 'entry' then 1
+
+            when service_name = 'club' and funnel_stage = 'detail' then 4
+            when service_name = 'club' and funnel_stage = 'club_view' then 3
+            when service_name = 'club' and funnel_stage = 'explore' then 2
+            when service_name = 'club' and funnel_stage = 'entry' then 1
+
+            when service_name = 'banner' and funnel_stage = 'click' then 2
+            when service_name = 'banner' and funnel_stage = 'impression' then 1
+
+            when service_name = 'facility' and funnel_stage = 'entry' then 1
+
+            when service_name = 'timetable' and funnel_stage = 'save' then 3
+            when service_name = 'timetable' and funnel_stage = 'explore' then 2
+            when service_name = 'timetable' and funnel_stage = 'entry' then 1
+
+            when service_name = 'grad_calc' and funnel_stage = 'explore' then 2
+            when service_name = 'grad_calc' and funnel_stage = 'entry' then 1
+
+            when service_name = 'account' and funnel_stage = 'signup_complete' then 5
+            when service_name = 'account' and funnel_stage = 'form_entry' then 4
+            when service_name = 'account'
+                and funnel_stage = 'identity_verification'
+                then 3
+            when service_name = 'account' and funnel_stage = 'terms_agreement' then 2
+            when service_name = 'account' and funnel_stage = 'signup_start' then 1
+            when service_name = 'account' and funnel_stage = 'login_entry' then 1
+
+            when service_name = 'main' and funnel_stage = 'main' then 0
+            else null
+        end as step_order
+    from funnel_mapped
+
+),
+
+classified as (
+
+    select
+        * except (funnel_stage, step_order),
+        funnel_stage,
+        step_order,
+        (funnel_stage = 'entry') as is_entry_event,
+        case
+            when funnel_stage is null then null
+            when service_name = 'board' and funnel_stage = 'read' then true
+            when service_name = 'shop' and funnel_stage = 'call' then true
+            when service_name = 'cafeteria' and funnel_stage = 'share' then true
+            when service_name = 'bus' and funnel_stage = 'search' then true
+            when service_name = 'club' and funnel_stage = 'detail' then true
+            when service_name = 'banner' and funnel_stage = 'click' then true
+            when service_name = 'timetable' and funnel_stage = 'save' then true
+            when service_name = 'account' and funnel_stage = 'signup_complete' then true
+            else false
+        end as is_core_action,
+        case when service_name = 'main' then 'global' else 'service' end as stage_scope,
+        case when service_name = 'main' then null else step_order end as service_step_order
+    from step_order_mapped
+
+)
+
+select *
+from classified

--- a/dbt/models/silver/silver_events_v2.sql
+++ b/dbt/models/silver/silver_events_v2.sql
@@ -565,31 +565,46 @@ signup_sessionized as (
 
 ),
 
+event_label_corrected as (
+
+    select
+        signup_sessionized.* except (event_label),
+        case
+            when platform = 'IOS'
+                and lower(trim(event_label)) = 'find_user_write'
+                and trim(event_value) = '잃어버렸어요'
+                then 'lost_item_write'
+            else event_label
+        end as event_label
+    from signup_sessionized
+
+),
+
 final_target_dates as (
 
     select
-        signup_sessionized.event_id,
-        signup_sessionized.event_dt,
-        signup_sessionized.event_at,
-        signup_sessionized.event_ts,
-        signup_sessionized.event_name,
-        signup_sessionized.user_pseudo_id,
-        signup_sessionized.ga_session_id,
-        signup_sessionized.custom_session_id,
-        signup_sessionized.platform,
-        signup_sessionized.device_category,
-        signup_sessionized.device_os,
-        signup_sessionized.device_os_version,
-        signup_sessionized.event_label,
-        signup_sessionized.event_category,
-        signup_sessionized.event_value,
-        signup_sessionized.page_title,
-        signup_sessionized.screen_class,
-        signup_sessionized.engagement_time_msec,
-        signup_sessionized.page_location
-    from signup_sessionized
+        event_label_corrected.event_id,
+        event_label_corrected.event_dt,
+        event_label_corrected.event_at,
+        event_label_corrected.event_ts,
+        event_label_corrected.event_name,
+        event_label_corrected.user_pseudo_id,
+        event_label_corrected.ga_session_id,
+        event_label_corrected.custom_session_id,
+        event_label_corrected.platform,
+        event_label_corrected.device_category,
+        event_label_corrected.device_os,
+        event_label_corrected.device_os_version,
+        event_label_corrected.event_label,
+        event_label_corrected.event_category,
+        event_label_corrected.event_value,
+        event_label_corrected.page_title,
+        event_label_corrected.screen_class,
+        event_label_corrected.engagement_time_msec,
+        event_label_corrected.page_location
+    from event_label_corrected
     cross join date_window
-    where signup_sessionized.event_dt between date_window.target_start_dt and date_window.target_end_dt
+    where event_label_corrected.event_dt between date_window.target_start_dt and date_window.target_end_dt
 
 ),
 


### PR DESCRIPTION
## 변경 사항
- Stage에서 검증한 이벤트 모델을 별도 운영 모델 `silver_events_v2`로 추가했습니다.
- 프로덕션 GA4 및 app_db 원천을 사용하는 `silver__users` 모델과 계약·source 정의를 추가했습니다.
- GA4 source 기본값을 프로덕션 원천으로 명시했습니다.

## 목적
기존 `silver_events`와 분리된 V2 테이블로 운영 적재를 준비하고, users Silver 모델을 dbt에서 컴파일·실행할 수 있게 합니다.

## 영향
- 이 PR은 dbt SQL/YAML만 포함합니다.
- Airflow, Docker, credential, .env 및 Stage 임시 모델은 포함하지 않습니다.
- 병합 후에도 배포 및 수동 dbt 실행은 별도 운영 절차가 필요합니다.

## 검증
- Windows 로컬 dbt `parse` 및 `ls` 성공
- Docker Airflow dbt venv에서 `parse` 성공
- 날짜 범위(`20260701`~`20260703`)로 `silver_events_v2`, `silver__users` `compile` 성공
- `git diff --check origin/main..codex/prod-dbt-v2` 성공